### PR TITLE
Check correctness of arguments and minor changes in options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+
+hedge_cli
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build
+
+build:
+	@go mod tidy
+	@go mod vendor
+	@mkdir -p build
+	@go build -o build/hedge_cli
+
+clean:
+	@rm -fr build

--- a/hedge_cli.go
+++ b/hedge_cli.go
@@ -12,7 +12,7 @@ func main() {
 
 	app.Name = "hedgecli"
 	app.Usage = "A CLI tool to manage hedge VMs"
-	app.Version = "0.0.1"
+	app.Version = "0.0.3"
 	// 	app.Description = `
 	// hedgecli is a tool that allows users to start, stop and manage hedge VMs`
 	app.Commands = Commands()

--- a/vendor/github.com/cpuguy83/go-md2man/v2/LICENSE.md
+++ b/vendor/github.com/cpuguy83/go-md2man/v2/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Brian Goff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/cpuguy83/go-md2man/v2/md2man/md2man.go
+++ b/vendor/github.com/cpuguy83/go-md2man/v2/md2man/md2man.go
@@ -1,0 +1,14 @@
+package md2man
+
+import (
+	"github.com/russross/blackfriday/v2"
+)
+
+// Render converts a markdown document into a roff formatted document.
+func Render(doc []byte) []byte {
+	renderer := NewRoffRenderer()
+
+	return blackfriday.Run(doc,
+		[]blackfriday.Option{blackfriday.WithRenderer(renderer),
+			blackfriday.WithExtensions(renderer.GetExtensions())}...)
+}

--- a/vendor/github.com/cpuguy83/go-md2man/v2/md2man/roff.go
+++ b/vendor/github.com/cpuguy83/go-md2man/v2/md2man/roff.go
@@ -1,0 +1,345 @@
+package md2man
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/russross/blackfriday/v2"
+)
+
+// roffRenderer implements the blackfriday.Renderer interface for creating
+// roff format (manpages) from markdown text
+type roffRenderer struct {
+	extensions   blackfriday.Extensions
+	listCounters []int
+	firstHeader  bool
+	defineTerm   bool
+	listDepth    int
+}
+
+const (
+	titleHeader      = ".TH "
+	topLevelHeader   = "\n\n.SH "
+	secondLevelHdr   = "\n.SH "
+	otherHeader      = "\n.SS "
+	crTag            = "\n"
+	emphTag          = "\\fI"
+	emphCloseTag     = "\\fP"
+	strongTag        = "\\fB"
+	strongCloseTag   = "\\fP"
+	breakTag         = "\n.br\n"
+	paraTag          = "\n.PP\n"
+	hruleTag         = "\n.ti 0\n\\l'\\n(.lu'\n"
+	linkTag          = "\n\\[la]"
+	linkCloseTag     = "\\[ra]"
+	codespanTag      = "\\fB\\fC"
+	codespanCloseTag = "\\fR"
+	codeTag          = "\n.PP\n.RS\n\n.nf\n"
+	codeCloseTag     = "\n.fi\n.RE\n"
+	quoteTag         = "\n.PP\n.RS\n"
+	quoteCloseTag    = "\n.RE\n"
+	listTag          = "\n.RS\n"
+	listCloseTag     = "\n.RE\n"
+	arglistTag       = "\n.TP\n"
+	tableStart       = "\n.TS\nallbox;\n"
+	tableEnd         = ".TE\n"
+	tableCellStart   = "T{\n"
+	tableCellEnd     = "\nT}\n"
+)
+
+// NewRoffRenderer creates a new blackfriday Renderer for generating roff documents
+// from markdown
+func NewRoffRenderer() *roffRenderer { // nolint: golint
+	var extensions blackfriday.Extensions
+
+	extensions |= blackfriday.NoIntraEmphasis
+	extensions |= blackfriday.Tables
+	extensions |= blackfriday.FencedCode
+	extensions |= blackfriday.SpaceHeadings
+	extensions |= blackfriday.Footnotes
+	extensions |= blackfriday.Titleblock
+	extensions |= blackfriday.DefinitionLists
+	return &roffRenderer{
+		extensions: extensions,
+	}
+}
+
+// GetExtensions returns the list of extensions used by this renderer implementation
+func (r *roffRenderer) GetExtensions() blackfriday.Extensions {
+	return r.extensions
+}
+
+// RenderHeader handles outputting the header at document start
+func (r *roffRenderer) RenderHeader(w io.Writer, ast *blackfriday.Node) {
+	// disable hyphenation
+	out(w, ".nh\n")
+}
+
+// RenderFooter handles outputting the footer at the document end; the roff
+// renderer has no footer information
+func (r *roffRenderer) RenderFooter(w io.Writer, ast *blackfriday.Node) {
+}
+
+// RenderNode is called for each node in a markdown document; based on the node
+// type the equivalent roff output is sent to the writer
+func (r *roffRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+
+	var walkAction = blackfriday.GoToNext
+
+	switch node.Type {
+	case blackfriday.Text:
+		r.handleText(w, node, entering)
+	case blackfriday.Softbreak:
+		out(w, crTag)
+	case blackfriday.Hardbreak:
+		out(w, breakTag)
+	case blackfriday.Emph:
+		if entering {
+			out(w, emphTag)
+		} else {
+			out(w, emphCloseTag)
+		}
+	case blackfriday.Strong:
+		if entering {
+			out(w, strongTag)
+		} else {
+			out(w, strongCloseTag)
+		}
+	case blackfriday.Link:
+		if !entering {
+			out(w, linkTag+string(node.LinkData.Destination)+linkCloseTag)
+		}
+	case blackfriday.Image:
+		// ignore images
+		walkAction = blackfriday.SkipChildren
+	case blackfriday.Code:
+		out(w, codespanTag)
+		escapeSpecialChars(w, node.Literal)
+		out(w, codespanCloseTag)
+	case blackfriday.Document:
+		break
+	case blackfriday.Paragraph:
+		// roff .PP markers break lists
+		if r.listDepth > 0 {
+			return blackfriday.GoToNext
+		}
+		if entering {
+			out(w, paraTag)
+		} else {
+			out(w, crTag)
+		}
+	case blackfriday.BlockQuote:
+		if entering {
+			out(w, quoteTag)
+		} else {
+			out(w, quoteCloseTag)
+		}
+	case blackfriday.Heading:
+		r.handleHeading(w, node, entering)
+	case blackfriday.HorizontalRule:
+		out(w, hruleTag)
+	case blackfriday.List:
+		r.handleList(w, node, entering)
+	case blackfriday.Item:
+		r.handleItem(w, node, entering)
+	case blackfriday.CodeBlock:
+		out(w, codeTag)
+		escapeSpecialChars(w, node.Literal)
+		out(w, codeCloseTag)
+	case blackfriday.Table:
+		r.handleTable(w, node, entering)
+	case blackfriday.TableCell:
+		r.handleTableCell(w, node, entering)
+	case blackfriday.TableHead:
+	case blackfriday.TableBody:
+	case blackfriday.TableRow:
+		// no action as cell entries do all the nroff formatting
+		return blackfriday.GoToNext
+	default:
+		fmt.Fprintln(os.Stderr, "WARNING: go-md2man does not handle node type "+node.Type.String())
+	}
+	return walkAction
+}
+
+func (r *roffRenderer) handleText(w io.Writer, node *blackfriday.Node, entering bool) {
+	var (
+		start, end string
+	)
+	// handle special roff table cell text encapsulation
+	if node.Parent.Type == blackfriday.TableCell {
+		if len(node.Literal) > 30 {
+			start = tableCellStart
+			end = tableCellEnd
+		} else {
+			// end rows that aren't terminated by "tableCellEnd" with a cr if end of row
+			if node.Parent.Next == nil && !node.Parent.IsHeader {
+				end = crTag
+			}
+		}
+	}
+	out(w, start)
+	escapeSpecialChars(w, node.Literal)
+	out(w, end)
+}
+
+func (r *roffRenderer) handleHeading(w io.Writer, node *blackfriday.Node, entering bool) {
+	if entering {
+		switch node.Level {
+		case 1:
+			if !r.firstHeader {
+				out(w, titleHeader)
+				r.firstHeader = true
+				break
+			}
+			out(w, topLevelHeader)
+		case 2:
+			out(w, secondLevelHdr)
+		default:
+			out(w, otherHeader)
+		}
+	}
+}
+
+func (r *roffRenderer) handleList(w io.Writer, node *blackfriday.Node, entering bool) {
+	openTag := listTag
+	closeTag := listCloseTag
+	if node.ListFlags&blackfriday.ListTypeDefinition != 0 {
+		// tags for definition lists handled within Item node
+		openTag = ""
+		closeTag = ""
+	}
+	if entering {
+		r.listDepth++
+		if node.ListFlags&blackfriday.ListTypeOrdered != 0 {
+			r.listCounters = append(r.listCounters, 1)
+		}
+		out(w, openTag)
+	} else {
+		if node.ListFlags&blackfriday.ListTypeOrdered != 0 {
+			r.listCounters = r.listCounters[:len(r.listCounters)-1]
+		}
+		out(w, closeTag)
+		r.listDepth--
+	}
+}
+
+func (r *roffRenderer) handleItem(w io.Writer, node *blackfriday.Node, entering bool) {
+	if entering {
+		if node.ListFlags&blackfriday.ListTypeOrdered != 0 {
+			out(w, fmt.Sprintf(".IP \"%3d.\" 5\n", r.listCounters[len(r.listCounters)-1]))
+			r.listCounters[len(r.listCounters)-1]++
+		} else if node.ListFlags&blackfriday.ListTypeDefinition != 0 {
+			// state machine for handling terms and following definitions
+			// since blackfriday does not distinguish them properly, nor
+			// does it seperate them into separate lists as it should
+			if !r.defineTerm {
+				out(w, arglistTag)
+				r.defineTerm = true
+			} else {
+				r.defineTerm = false
+			}
+		} else {
+			out(w, ".IP \\(bu 2\n")
+		}
+	} else {
+		out(w, "\n")
+	}
+}
+
+func (r *roffRenderer) handleTable(w io.Writer, node *blackfriday.Node, entering bool) {
+	if entering {
+		out(w, tableStart)
+		//call walker to count cells (and rows?) so format section can be produced
+		columns := countColumns(node)
+		out(w, strings.Repeat("l ", columns)+"\n")
+		out(w, strings.Repeat("l ", columns)+".\n")
+	} else {
+		out(w, tableEnd)
+	}
+}
+
+func (r *roffRenderer) handleTableCell(w io.Writer, node *blackfriday.Node, entering bool) {
+	var (
+		start, end string
+	)
+	if node.IsHeader {
+		start = codespanTag
+		end = codespanCloseTag
+	}
+	if entering {
+		if node.Prev != nil && node.Prev.Type == blackfriday.TableCell {
+			out(w, "\t"+start)
+		} else {
+			out(w, start)
+		}
+	} else {
+		// need to carriage return if we are at the end of the header row
+		if node.IsHeader && node.Next == nil {
+			end = end + crTag
+		}
+		out(w, end)
+	}
+}
+
+// because roff format requires knowing the column count before outputting any table
+// data we need to walk a table tree and count the columns
+func countColumns(node *blackfriday.Node) int {
+	var columns int
+
+	node.Walk(func(node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+		switch node.Type {
+		case blackfriday.TableRow:
+			if !entering {
+				return blackfriday.Terminate
+			}
+		case blackfriday.TableCell:
+			if entering {
+				columns++
+			}
+		default:
+		}
+		return blackfriday.GoToNext
+	})
+	return columns
+}
+
+func out(w io.Writer, output string) {
+	io.WriteString(w, output) // nolint: errcheck
+}
+
+func needsBackslash(c byte) bool {
+	for _, r := range []byte("-_&\\~") {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}
+
+func escapeSpecialChars(w io.Writer, text []byte) {
+	for i := 0; i < len(text); i++ {
+		// escape initial apostrophe or period
+		if len(text) >= 1 && (text[0] == '\'' || text[0] == '.') {
+			out(w, "\\&")
+		}
+
+		// directly copy normal characters
+		org := i
+
+		for i < len(text) && !needsBackslash(text[i]) {
+			i++
+		}
+		if i > org {
+			w.Write(text[org:i]) // nolint: errcheck
+		}
+
+		// escape a character
+		if i >= len(text) {
+			break
+		}
+
+		w.Write([]byte{'\\', text[i]}) // nolint: errcheck
+	}
+}

--- a/vendor/github.com/russross/blackfriday/v2/.gitignore
+++ b/vendor/github.com/russross/blackfriday/v2/.gitignore
@@ -1,0 +1,8 @@
+*.out
+*.swp
+*.8
+*.6
+_obj
+_test*
+markdown
+tags

--- a/vendor/github.com/russross/blackfriday/v2/.travis.yml
+++ b/vendor/github.com/russross/blackfriday/v2/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: go
+go:
+  - "1.10.x"
+  - "1.11.x"
+  - tip
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
+install:
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v ./...

--- a/vendor/github.com/russross/blackfriday/v2/LICENSE.txt
+++ b/vendor/github.com/russross/blackfriday/v2/LICENSE.txt
@@ -1,0 +1,29 @@
+Blackfriday is distributed under the Simplified BSD License:
+
+> Copyright © 2011 Russ Ross
+> All rights reserved.
+>
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions
+> are met:
+>
+> 1.  Redistributions of source code must retain the above copyright
+>     notice, this list of conditions and the following disclaimer.
+>
+> 2.  Redistributions in binary form must reproduce the above
+>     copyright notice, this list of conditions and the following
+>     disclaimer in the documentation and/or other materials provided with
+>     the distribution.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+> "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+> LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+> FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+> COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+> INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+> BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+> LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+> CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+> LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+> ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+> POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/russross/blackfriday/v2/README.md
+++ b/vendor/github.com/russross/blackfriday/v2/README.md
@@ -1,0 +1,291 @@
+Blackfriday [![Build Status](https://travis-ci.org/russross/blackfriday.svg?branch=master)](https://travis-ci.org/russross/blackfriday)
+===========
+
+Blackfriday is a [Markdown][1] processor implemented in [Go][2]. It
+is paranoid about its input (so you can safely feed it user-supplied
+data), it is fast, it supports common extensions (tables, smart
+punctuation substitutions, etc.), and it is safe for all utf-8
+(unicode) input.
+
+HTML output is currently supported, along with Smartypants
+extensions.
+
+It started as a translation from C of [Sundown][3].
+
+
+Installation
+------------
+
+Blackfriday is compatible with any modern Go release. With Go 1.7 and git
+installed:
+
+    go get gopkg.in/russross/blackfriday.v2
+
+will download, compile, and install the package into your `$GOPATH`
+directory hierarchy. Alternatively, you can achieve the same if you
+import it into a project:
+
+    import "gopkg.in/russross/blackfriday.v2"
+
+and `go get` without parameters.
+
+
+Versions
+--------
+
+Currently maintained and recommended version of Blackfriday is `v2`. It's being
+developed on its own branch: https://github.com/russross/blackfriday/tree/v2 and the
+documentation is available at
+https://godoc.org/gopkg.in/russross/blackfriday.v2.
+
+It is `go get`-able via via [gopkg.in][6] at `gopkg.in/russross/blackfriday.v2`,
+but we highly recommend using package management tool like [dep][7] or
+[Glide][8] and make use of semantic versioning. With package management you
+should import `github.com/russross/blackfriday` and specify that you're using
+version 2.0.0.
+
+Version 2 offers a number of improvements over v1:
+
+* Cleaned up API
+* A separate call to [`Parse`][4], which produces an abstract syntax tree for
+  the document
+* Latest bug fixes
+* Flexibility to easily add your own rendering extensions
+
+Potential drawbacks:
+
+* Our benchmarks show v2 to be slightly slower than v1. Currently in the
+  ballpark of around 15%.
+* API breakage. If you can't afford modifying your code to adhere to the new API
+  and don't care too much about the new features, v2 is probably not for you.
+* Several bug fixes are trailing behind and still need to be forward-ported to
+  v2. See issue [#348](https://github.com/russross/blackfriday/issues/348) for
+  tracking.
+
+Usage
+-----
+
+For the most sensible markdown processing, it is as simple as getting your input
+into a byte slice and calling:
+
+```go
+output := blackfriday.Run(input)
+```
+
+Your input will be parsed and the output rendered with a set of most popular
+extensions enabled. If you want the most basic feature set, corresponding with
+the bare Markdown specification, use:
+
+```go
+output := blackfriday.Run(input, blackfriday.WithNoExtensions())
+```
+
+### Sanitize untrusted content
+
+Blackfriday itself does nothing to protect against malicious content. If you are
+dealing with user-supplied markdown, we recommend running Blackfriday's output
+through HTML sanitizer such as [Bluemonday][5].
+
+Here's an example of simple usage of Blackfriday together with Bluemonday:
+
+```go
+import (
+    "github.com/microcosm-cc/bluemonday"
+    "github.com/russross/blackfriday"
+)
+
+// ...
+unsafe := blackfriday.Run(input)
+html := bluemonday.UGCPolicy().SanitizeBytes(unsafe)
+```
+
+### Custom options
+
+If you want to customize the set of options, use `blackfriday.WithExtensions`,
+`blackfriday.WithRenderer` and `blackfriday.WithRefOverride`.
+
+You can also check out `blackfriday-tool` for a more complete example
+of how to use it. Download and install it using:
+
+    go get github.com/russross/blackfriday-tool
+
+This is a simple command-line tool that allows you to process a
+markdown file using a standalone program.  You can also browse the
+source directly on github if you are just looking for some example
+code:
+
+* <http://github.com/russross/blackfriday-tool>
+
+Note that if you have not already done so, installing
+`blackfriday-tool` will be sufficient to download and install
+blackfriday in addition to the tool itself. The tool binary will be
+installed in `$GOPATH/bin`.  This is a statically-linked binary that
+can be copied to wherever you need it without worrying about
+dependencies and library versions.
+
+
+Features
+--------
+
+All features of Sundown are supported, including:
+
+*   **Compatibility**. The Markdown v1.0.3 test suite passes with
+    the `--tidy` option.  Without `--tidy`, the differences are
+    mostly in whitespace and entity escaping, where blackfriday is
+    more consistent and cleaner.
+
+*   **Common extensions**, including table support, fenced code
+    blocks, autolinks, strikethroughs, non-strict emphasis, etc.
+
+*   **Safety**. Blackfriday is paranoid when parsing, making it safe
+    to feed untrusted user input without fear of bad things
+    happening. The test suite stress tests this and there are no
+    known inputs that make it crash.  If you find one, please let me
+    know and send me the input that does it.
+
+    NOTE: "safety" in this context means *runtime safety only*. In order to
+    protect yourself against JavaScript injection in untrusted content, see
+    [this example](https://github.com/russross/blackfriday#sanitize-untrusted-content).
+
+*   **Fast processing**. It is fast enough to render on-demand in
+    most web applications without having to cache the output.
+
+*   **Thread safety**. You can run multiple parsers in different
+    goroutines without ill effect. There is no dependence on global
+    shared state.
+
+*   **Minimal dependencies**. Blackfriday only depends on standard
+    library packages in Go. The source code is pretty
+    self-contained, so it is easy to add to any project, including
+    Google App Engine projects.
+
+*   **Standards compliant**. Output successfully validates using the
+    W3C validation tool for HTML 4.01 and XHTML 1.0 Transitional.
+
+
+Extensions
+----------
+
+In addition to the standard markdown syntax, this package
+implements the following extensions:
+
+*   **Intra-word emphasis supression**. The `_` character is
+    commonly used inside words when discussing code, so having
+    markdown interpret it as an emphasis command is usually the
+    wrong thing. Blackfriday lets you treat all emphasis markers as
+    normal characters when they occur inside a word.
+
+*   **Tables**. Tables can be created by drawing them in the input
+    using a simple syntax:
+
+    ```
+    Name    | Age
+    --------|------
+    Bob     | 27
+    Alice   | 23
+    ```
+
+*   **Fenced code blocks**. In addition to the normal 4-space
+    indentation to mark code blocks, you can explicitly mark them
+    and supply a language (to make syntax highlighting simple). Just
+    mark it like this:
+
+        ```go
+        func getTrue() bool {
+            return true
+        }
+        ```
+
+    You can use 3 or more backticks to mark the beginning of the
+    block, and the same number to mark the end of the block.
+
+*   **Definition lists**. A simple definition list is made of a single-line
+    term followed by a colon and the definition for that term.
+
+        Cat
+        : Fluffy animal everyone likes
+
+        Internet
+        : Vector of transmission for pictures of cats
+
+    Terms must be separated from the previous definition by a blank line.
+
+*   **Footnotes**. A marker in the text that will become a superscript number;
+    a footnote definition that will be placed in a list of footnotes at the
+    end of the document. A footnote looks like this:
+
+        This is a footnote.[^1]
+
+        [^1]: the footnote text.
+
+*   **Autolinking**. Blackfriday can find URLs that have not been
+    explicitly marked as links and turn them into links.
+
+*   **Strikethrough**. Use two tildes (`~~`) to mark text that
+    should be crossed out.
+
+*   **Hard line breaks**. With this extension enabled newlines in the input
+    translate into line breaks in the output. This extension is off by default.
+
+*   **Smart quotes**. Smartypants-style punctuation substitution is
+    supported, turning normal double- and single-quote marks into
+    curly quotes, etc.
+
+*   **LaTeX-style dash parsing** is an additional option, where `--`
+    is translated into `&ndash;`, and `---` is translated into
+    `&mdash;`. This differs from most smartypants processors, which
+    turn a single hyphen into an ndash and a double hyphen into an
+    mdash.
+
+*   **Smart fractions**, where anything that looks like a fraction
+    is translated into suitable HTML (instead of just a few special
+    cases like most smartypant processors). For example, `4/5`
+    becomes `<sup>4</sup>&frasl;<sub>5</sub>`, which renders as
+    <sup>4</sup>&frasl;<sub>5</sub>.
+
+
+Other renderers
+---------------
+
+Blackfriday is structured to allow alternative rendering engines. Here
+are a few of note:
+
+*   [github_flavored_markdown](https://godoc.org/github.com/shurcooL/github_flavored_markdown):
+    provides a GitHub Flavored Markdown renderer with fenced code block
+    highlighting, clickable heading anchor links.
+
+    It's not customizable, and its goal is to produce HTML output
+    equivalent to the [GitHub Markdown API endpoint](https://developer.github.com/v3/markdown/#render-a-markdown-document-in-raw-mode),
+    except the rendering is performed locally.
+
+*   [markdownfmt](https://github.com/shurcooL/markdownfmt): like gofmt,
+    but for markdown.
+
+*   [LaTeX output](https://github.com/Ambrevar/Blackfriday-LaTeX):
+    renders output as LaTeX.
+
+*   [Blackfriday-Confluence](https://github.com/kentaro-m/blackfriday-confluence): provides a [Confluence Wiki Markup](https://confluence.atlassian.com/doc/confluence-wiki-markup-251003035.html) renderer.
+
+
+Todo
+----
+
+*   More unit testing
+*   Improve unicode support. It does not understand all unicode
+    rules (about what constitutes a letter, a punctuation symbol,
+    etc.), so it may fail to detect word boundaries correctly in
+    some instances. It is safe on all utf-8 input.
+
+
+License
+-------
+
+[Blackfriday is distributed under the Simplified BSD License](LICENSE.txt)
+
+
+   [1]: https://daringfireball.net/projects/markdown/ "Markdown"
+   [2]: https://golang.org/ "Go Language"
+   [3]: https://github.com/vmg/sundown "Sundown"
+   [4]: https://godoc.org/gopkg.in/russross/blackfriday.v2#Parse "Parse func"
+   [5]: https://github.com/microcosm-cc/bluemonday "Bluemonday"
+   [6]: https://labix.org/gopkg.in "gopkg.in"

--- a/vendor/github.com/russross/blackfriday/v2/block.go
+++ b/vendor/github.com/russross/blackfriday/v2/block.go
@@ -1,0 +1,1590 @@
+//
+// Blackfriday Markdown Processor
+// Available at http://github.com/russross/blackfriday
+//
+// Copyright © 2011 Russ Ross <russ@russross.com>.
+// Distributed under the Simplified BSD License.
+// See README.md for details.
+//
+
+//
+// Functions to parse block-level elements.
+//
+
+package blackfriday
+
+import (
+	"bytes"
+	"html"
+	"regexp"
+	"strings"
+
+	"github.com/shurcooL/sanitized_anchor_name"
+)
+
+const (
+	charEntity = "&(?:#x[a-f0-9]{1,8}|#[0-9]{1,8}|[a-z][a-z0-9]{1,31});"
+	escapable  = "[!\"#$%&'()*+,./:;<=>?@[\\\\\\]^_`{|}~-]"
+)
+
+var (
+	reBackslashOrAmp      = regexp.MustCompile("[\\&]")
+	reEntityOrEscapedChar = regexp.MustCompile("(?i)\\\\" + escapable + "|" + charEntity)
+)
+
+// Parse block-level data.
+// Note: this function and many that it calls assume that
+// the input buffer ends with a newline.
+func (p *Markdown) block(data []byte) {
+	// this is called recursively: enforce a maximum depth
+	if p.nesting >= p.maxNesting {
+		return
+	}
+	p.nesting++
+
+	// parse out one block-level construct at a time
+	for len(data) > 0 {
+		// prefixed heading:
+		//
+		// # Heading 1
+		// ## Heading 2
+		// ...
+		// ###### Heading 6
+		if p.isPrefixHeading(data) {
+			data = data[p.prefixHeading(data):]
+			continue
+		}
+
+		// block of preformatted HTML:
+		//
+		// <div>
+		//     ...
+		// </div>
+		if data[0] == '<' {
+			if i := p.html(data, true); i > 0 {
+				data = data[i:]
+				continue
+			}
+		}
+
+		// title block
+		//
+		// % stuff
+		// % more stuff
+		// % even more stuff
+		if p.extensions&Titleblock != 0 {
+			if data[0] == '%' {
+				if i := p.titleBlock(data, true); i > 0 {
+					data = data[i:]
+					continue
+				}
+			}
+		}
+
+		// blank lines.  note: returns the # of bytes to skip
+		if i := p.isEmpty(data); i > 0 {
+			data = data[i:]
+			continue
+		}
+
+		// indented code block:
+		//
+		//     func max(a, b int) int {
+		//         if a > b {
+		//             return a
+		//         }
+		//         return b
+		//      }
+		if p.codePrefix(data) > 0 {
+			data = data[p.code(data):]
+			continue
+		}
+
+		// fenced code block:
+		//
+		// ``` go
+		// func fact(n int) int {
+		//     if n <= 1 {
+		//         return n
+		//     }
+		//     return n * fact(n-1)
+		// }
+		// ```
+		if p.extensions&FencedCode != 0 {
+			if i := p.fencedCodeBlock(data, true); i > 0 {
+				data = data[i:]
+				continue
+			}
+		}
+
+		// horizontal rule:
+		//
+		// ------
+		// or
+		// ******
+		// or
+		// ______
+		if p.isHRule(data) {
+			p.addBlock(HorizontalRule, nil)
+			var i int
+			for i = 0; i < len(data) && data[i] != '\n'; i++ {
+			}
+			data = data[i:]
+			continue
+		}
+
+		// block quote:
+		//
+		// > A big quote I found somewhere
+		// > on the web
+		if p.quotePrefix(data) > 0 {
+			data = data[p.quote(data):]
+			continue
+		}
+
+		// table:
+		//
+		// Name  | Age | Phone
+		// ------|-----|---------
+		// Bob   | 31  | 555-1234
+		// Alice | 27  | 555-4321
+		if p.extensions&Tables != 0 {
+			if i := p.table(data); i > 0 {
+				data = data[i:]
+				continue
+			}
+		}
+
+		// an itemized/unordered list:
+		//
+		// * Item 1
+		// * Item 2
+		//
+		// also works with + or -
+		if p.uliPrefix(data) > 0 {
+			data = data[p.list(data, 0):]
+			continue
+		}
+
+		// a numbered/ordered list:
+		//
+		// 1. Item 1
+		// 2. Item 2
+		if p.oliPrefix(data) > 0 {
+			data = data[p.list(data, ListTypeOrdered):]
+			continue
+		}
+
+		// definition lists:
+		//
+		// Term 1
+		// :   Definition a
+		// :   Definition b
+		//
+		// Term 2
+		// :   Definition c
+		if p.extensions&DefinitionLists != 0 {
+			if p.dliPrefix(data) > 0 {
+				data = data[p.list(data, ListTypeDefinition):]
+				continue
+			}
+		}
+
+		// anything else must look like a normal paragraph
+		// note: this finds underlined headings, too
+		data = data[p.paragraph(data):]
+	}
+
+	p.nesting--
+}
+
+func (p *Markdown) addBlock(typ NodeType, content []byte) *Node {
+	p.closeUnmatchedBlocks()
+	container := p.addChild(typ, 0)
+	container.content = content
+	return container
+}
+
+func (p *Markdown) isPrefixHeading(data []byte) bool {
+	if data[0] != '#' {
+		return false
+	}
+
+	if p.extensions&SpaceHeadings != 0 {
+		level := 0
+		for level < 6 && level < len(data) && data[level] == '#' {
+			level++
+		}
+		if level == len(data) || data[level] != ' ' {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *Markdown) prefixHeading(data []byte) int {
+	level := 0
+	for level < 6 && level < len(data) && data[level] == '#' {
+		level++
+	}
+	i := skipChar(data, level, ' ')
+	end := skipUntilChar(data, i, '\n')
+	skip := end
+	id := ""
+	if p.extensions&HeadingIDs != 0 {
+		j, k := 0, 0
+		// find start/end of heading id
+		for j = i; j < end-1 && (data[j] != '{' || data[j+1] != '#'); j++ {
+		}
+		for k = j + 1; k < end && data[k] != '}'; k++ {
+		}
+		// extract heading id iff found
+		if j < end && k < end {
+			id = string(data[j+2 : k])
+			end = j
+			skip = k + 1
+			for end > 0 && data[end-1] == ' ' {
+				end--
+			}
+		}
+	}
+	for end > 0 && data[end-1] == '#' {
+		if isBackslashEscaped(data, end-1) {
+			break
+		}
+		end--
+	}
+	for end > 0 && data[end-1] == ' ' {
+		end--
+	}
+	if end > i {
+		if id == "" && p.extensions&AutoHeadingIDs != 0 {
+			id = sanitized_anchor_name.Create(string(data[i:end]))
+		}
+		block := p.addBlock(Heading, data[i:end])
+		block.HeadingID = id
+		block.Level = level
+	}
+	return skip
+}
+
+func (p *Markdown) isUnderlinedHeading(data []byte) int {
+	// test of level 1 heading
+	if data[0] == '=' {
+		i := skipChar(data, 1, '=')
+		i = skipChar(data, i, ' ')
+		if i < len(data) && data[i] == '\n' {
+			return 1
+		}
+		return 0
+	}
+
+	// test of level 2 heading
+	if data[0] == '-' {
+		i := skipChar(data, 1, '-')
+		i = skipChar(data, i, ' ')
+		if i < len(data) && data[i] == '\n' {
+			return 2
+		}
+		return 0
+	}
+
+	return 0
+}
+
+func (p *Markdown) titleBlock(data []byte, doRender bool) int {
+	if data[0] != '%' {
+		return 0
+	}
+	splitData := bytes.Split(data, []byte("\n"))
+	var i int
+	for idx, b := range splitData {
+		if !bytes.HasPrefix(b, []byte("%")) {
+			i = idx // - 1
+			break
+		}
+	}
+
+	data = bytes.Join(splitData[0:i], []byte("\n"))
+	consumed := len(data)
+	data = bytes.TrimPrefix(data, []byte("% "))
+	data = bytes.Replace(data, []byte("\n% "), []byte("\n"), -1)
+	block := p.addBlock(Heading, data)
+	block.Level = 1
+	block.IsTitleblock = true
+
+	return consumed
+}
+
+func (p *Markdown) html(data []byte, doRender bool) int {
+	var i, j int
+
+	// identify the opening tag
+	if data[0] != '<' {
+		return 0
+	}
+	curtag, tagfound := p.htmlFindTag(data[1:])
+
+	// handle special cases
+	if !tagfound {
+		// check for an HTML comment
+		if size := p.htmlComment(data, doRender); size > 0 {
+			return size
+		}
+
+		// check for an <hr> tag
+		if size := p.htmlHr(data, doRender); size > 0 {
+			return size
+		}
+
+		// no special case recognized
+		return 0
+	}
+
+	// look for an unindented matching closing tag
+	// followed by a blank line
+	found := false
+	/*
+		closetag := []byte("\n</" + curtag + ">")
+		j = len(curtag) + 1
+		for !found {
+			// scan for a closing tag at the beginning of a line
+			if skip := bytes.Index(data[j:], closetag); skip >= 0 {
+				j += skip + len(closetag)
+			} else {
+				break
+			}
+
+			// see if it is the only thing on the line
+			if skip := p.isEmpty(data[j:]); skip > 0 {
+				// see if it is followed by a blank line/eof
+				j += skip
+				if j >= len(data) {
+					found = true
+					i = j
+				} else {
+					if skip := p.isEmpty(data[j:]); skip > 0 {
+						j += skip
+						found = true
+						i = j
+					}
+				}
+			}
+		}
+	*/
+
+	// if not found, try a second pass looking for indented match
+	// but not if tag is "ins" or "del" (following original Markdown.pl)
+	if !found && curtag != "ins" && curtag != "del" {
+		i = 1
+		for i < len(data) {
+			i++
+			for i < len(data) && !(data[i-1] == '<' && data[i] == '/') {
+				i++
+			}
+
+			if i+2+len(curtag) >= len(data) {
+				break
+			}
+
+			j = p.htmlFindEnd(curtag, data[i-1:])
+
+			if j > 0 {
+				i += j - 1
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		return 0
+	}
+
+	// the end of the block has been found
+	if doRender {
+		// trim newlines
+		end := i
+		for end > 0 && data[end-1] == '\n' {
+			end--
+		}
+		finalizeHTMLBlock(p.addBlock(HTMLBlock, data[:end]))
+	}
+
+	return i
+}
+
+func finalizeHTMLBlock(block *Node) {
+	block.Literal = block.content
+	block.content = nil
+}
+
+// HTML comment, lax form
+func (p *Markdown) htmlComment(data []byte, doRender bool) int {
+	i := p.inlineHTMLComment(data)
+	// needs to end with a blank line
+	if j := p.isEmpty(data[i:]); j > 0 {
+		size := i + j
+		if doRender {
+			// trim trailing newlines
+			end := size
+			for end > 0 && data[end-1] == '\n' {
+				end--
+			}
+			block := p.addBlock(HTMLBlock, data[:end])
+			finalizeHTMLBlock(block)
+		}
+		return size
+	}
+	return 0
+}
+
+// HR, which is the only self-closing block tag considered
+func (p *Markdown) htmlHr(data []byte, doRender bool) int {
+	if len(data) < 4 {
+		return 0
+	}
+	if data[0] != '<' || (data[1] != 'h' && data[1] != 'H') || (data[2] != 'r' && data[2] != 'R') {
+		return 0
+	}
+	if data[3] != ' ' && data[3] != '/' && data[3] != '>' {
+		// not an <hr> tag after all; at least not a valid one
+		return 0
+	}
+	i := 3
+	for i < len(data) && data[i] != '>' && data[i] != '\n' {
+		i++
+	}
+	if i < len(data) && data[i] == '>' {
+		i++
+		if j := p.isEmpty(data[i:]); j > 0 {
+			size := i + j
+			if doRender {
+				// trim newlines
+				end := size
+				for end > 0 && data[end-1] == '\n' {
+					end--
+				}
+				finalizeHTMLBlock(p.addBlock(HTMLBlock, data[:end]))
+			}
+			return size
+		}
+	}
+	return 0
+}
+
+func (p *Markdown) htmlFindTag(data []byte) (string, bool) {
+	i := 0
+	for i < len(data) && isalnum(data[i]) {
+		i++
+	}
+	key := string(data[:i])
+	if _, ok := blockTags[key]; ok {
+		return key, true
+	}
+	return "", false
+}
+
+func (p *Markdown) htmlFindEnd(tag string, data []byte) int {
+	// assume data[0] == '<' && data[1] == '/' already tested
+	if tag == "hr" {
+		return 2
+	}
+	// check if tag is a match
+	closetag := []byte("</" + tag + ">")
+	if !bytes.HasPrefix(data, closetag) {
+		return 0
+	}
+	i := len(closetag)
+
+	// check that the rest of the line is blank
+	skip := 0
+	if skip = p.isEmpty(data[i:]); skip == 0 {
+		return 0
+	}
+	i += skip
+	skip = 0
+
+	if i >= len(data) {
+		return i
+	}
+
+	if p.extensions&LaxHTMLBlocks != 0 {
+		return i
+	}
+	if skip = p.isEmpty(data[i:]); skip == 0 {
+		// following line must be blank
+		return 0
+	}
+
+	return i + skip
+}
+
+func (*Markdown) isEmpty(data []byte) int {
+	// it is okay to call isEmpty on an empty buffer
+	if len(data) == 0 {
+		return 0
+	}
+
+	var i int
+	for i = 0; i < len(data) && data[i] != '\n'; i++ {
+		if data[i] != ' ' && data[i] != '\t' {
+			return 0
+		}
+	}
+	if i < len(data) && data[i] == '\n' {
+		i++
+	}
+	return i
+}
+
+func (*Markdown) isHRule(data []byte) bool {
+	i := 0
+
+	// skip up to three spaces
+	for i < 3 && data[i] == ' ' {
+		i++
+	}
+
+	// look at the hrule char
+	if data[i] != '*' && data[i] != '-' && data[i] != '_' {
+		return false
+	}
+	c := data[i]
+
+	// the whole line must be the char or whitespace
+	n := 0
+	for i < len(data) && data[i] != '\n' {
+		switch {
+		case data[i] == c:
+			n++
+		case data[i] != ' ':
+			return false
+		}
+		i++
+	}
+
+	return n >= 3
+}
+
+// isFenceLine checks if there's a fence line (e.g., ``` or ``` go) at the beginning of data,
+// and returns the end index if so, or 0 otherwise. It also returns the marker found.
+// If info is not nil, it gets set to the syntax specified in the fence line.
+func isFenceLine(data []byte, info *string, oldmarker string) (end int, marker string) {
+	i, size := 0, 0
+
+	// skip up to three spaces
+	for i < len(data) && i < 3 && data[i] == ' ' {
+		i++
+	}
+
+	// check for the marker characters: ~ or `
+	if i >= len(data) {
+		return 0, ""
+	}
+	if data[i] != '~' && data[i] != '`' {
+		return 0, ""
+	}
+
+	c := data[i]
+
+	// the whole line must be the same char or whitespace
+	for i < len(data) && data[i] == c {
+		size++
+		i++
+	}
+
+	// the marker char must occur at least 3 times
+	if size < 3 {
+		return 0, ""
+	}
+	marker = string(data[i-size : i])
+
+	// if this is the end marker, it must match the beginning marker
+	if oldmarker != "" && marker != oldmarker {
+		return 0, ""
+	}
+
+	// TODO(shurcooL): It's probably a good idea to simplify the 2 code paths here
+	// into one, always get the info string, and discard it if the caller doesn't care.
+	if info != nil {
+		infoLength := 0
+		i = skipChar(data, i, ' ')
+
+		if i >= len(data) {
+			if i == len(data) {
+				return i, marker
+			}
+			return 0, ""
+		}
+
+		infoStart := i
+
+		if data[i] == '{' {
+			i++
+			infoStart++
+
+			for i < len(data) && data[i] != '}' && data[i] != '\n' {
+				infoLength++
+				i++
+			}
+
+			if i >= len(data) || data[i] != '}' {
+				return 0, ""
+			}
+
+			// strip all whitespace at the beginning and the end
+			// of the {} block
+			for infoLength > 0 && isspace(data[infoStart]) {
+				infoStart++
+				infoLength--
+			}
+
+			for infoLength > 0 && isspace(data[infoStart+infoLength-1]) {
+				infoLength--
+			}
+			i++
+			i = skipChar(data, i, ' ')
+		} else {
+			for i < len(data) && !isverticalspace(data[i]) {
+				infoLength++
+				i++
+			}
+		}
+
+		*info = strings.TrimSpace(string(data[infoStart : infoStart+infoLength]))
+	}
+
+	if i == len(data) {
+		return i, marker
+	}
+	if i > len(data) || data[i] != '\n' {
+		return 0, ""
+	}
+	return i + 1, marker // Take newline into account.
+}
+
+// fencedCodeBlock returns the end index if data contains a fenced code block at the beginning,
+// or 0 otherwise. It writes to out if doRender is true, otherwise it has no side effects.
+// If doRender is true, a final newline is mandatory to recognize the fenced code block.
+func (p *Markdown) fencedCodeBlock(data []byte, doRender bool) int {
+	var info string
+	beg, marker := isFenceLine(data, &info, "")
+	if beg == 0 || beg >= len(data) {
+		return 0
+	}
+
+	var work bytes.Buffer
+	work.Write([]byte(info))
+	work.WriteByte('\n')
+
+	for {
+		// safe to assume beg < len(data)
+
+		// check for the end of the code block
+		fenceEnd, _ := isFenceLine(data[beg:], nil, marker)
+		if fenceEnd != 0 {
+			beg += fenceEnd
+			break
+		}
+
+		// copy the current line
+		end := skipUntilChar(data, beg, '\n') + 1
+
+		// did we reach the end of the buffer without a closing marker?
+		if end >= len(data) {
+			return 0
+		}
+
+		// verbatim copy to the working buffer
+		if doRender {
+			work.Write(data[beg:end])
+		}
+		beg = end
+	}
+
+	if doRender {
+		block := p.addBlock(CodeBlock, work.Bytes()) // TODO: get rid of temp buffer
+		block.IsFenced = true
+		finalizeCodeBlock(block)
+	}
+
+	return beg
+}
+
+func unescapeChar(str []byte) []byte {
+	if str[0] == '\\' {
+		return []byte{str[1]}
+	}
+	return []byte(html.UnescapeString(string(str)))
+}
+
+func unescapeString(str []byte) []byte {
+	if reBackslashOrAmp.Match(str) {
+		return reEntityOrEscapedChar.ReplaceAllFunc(str, unescapeChar)
+	}
+	return str
+}
+
+func finalizeCodeBlock(block *Node) {
+	if block.IsFenced {
+		newlinePos := bytes.IndexByte(block.content, '\n')
+		firstLine := block.content[:newlinePos]
+		rest := block.content[newlinePos+1:]
+		block.Info = unescapeString(bytes.Trim(firstLine, "\n"))
+		block.Literal = rest
+	} else {
+		block.Literal = block.content
+	}
+	block.content = nil
+}
+
+func (p *Markdown) table(data []byte) int {
+	table := p.addBlock(Table, nil)
+	i, columns := p.tableHeader(data)
+	if i == 0 {
+		p.tip = table.Parent
+		table.Unlink()
+		return 0
+	}
+
+	p.addBlock(TableBody, nil)
+
+	for i < len(data) {
+		pipes, rowStart := 0, i
+		for ; i < len(data) && data[i] != '\n'; i++ {
+			if data[i] == '|' {
+				pipes++
+			}
+		}
+
+		if pipes == 0 {
+			i = rowStart
+			break
+		}
+
+		// include the newline in data sent to tableRow
+		if i < len(data) && data[i] == '\n' {
+			i++
+		}
+		p.tableRow(data[rowStart:i], columns, false)
+	}
+
+	return i
+}
+
+// check if the specified position is preceded by an odd number of backslashes
+func isBackslashEscaped(data []byte, i int) bool {
+	backslashes := 0
+	for i-backslashes-1 >= 0 && data[i-backslashes-1] == '\\' {
+		backslashes++
+	}
+	return backslashes&1 == 1
+}
+
+func (p *Markdown) tableHeader(data []byte) (size int, columns []CellAlignFlags) {
+	i := 0
+	colCount := 1
+	for i = 0; i < len(data) && data[i] != '\n'; i++ {
+		if data[i] == '|' && !isBackslashEscaped(data, i) {
+			colCount++
+		}
+	}
+
+	// doesn't look like a table header
+	if colCount == 1 {
+		return
+	}
+
+	// include the newline in the data sent to tableRow
+	j := i
+	if j < len(data) && data[j] == '\n' {
+		j++
+	}
+	header := data[:j]
+
+	// column count ignores pipes at beginning or end of line
+	if data[0] == '|' {
+		colCount--
+	}
+	if i > 2 && data[i-1] == '|' && !isBackslashEscaped(data, i-1) {
+		colCount--
+	}
+
+	columns = make([]CellAlignFlags, colCount)
+
+	// move on to the header underline
+	i++
+	if i >= len(data) {
+		return
+	}
+
+	if data[i] == '|' && !isBackslashEscaped(data, i) {
+		i++
+	}
+	i = skipChar(data, i, ' ')
+
+	// each column header is of form: / *:?-+:? *|/ with # dashes + # colons >= 3
+	// and trailing | optional on last column
+	col := 0
+	for i < len(data) && data[i] != '\n' {
+		dashes := 0
+
+		if data[i] == ':' {
+			i++
+			columns[col] |= TableAlignmentLeft
+			dashes++
+		}
+		for i < len(data) && data[i] == '-' {
+			i++
+			dashes++
+		}
+		if i < len(data) && data[i] == ':' {
+			i++
+			columns[col] |= TableAlignmentRight
+			dashes++
+		}
+		for i < len(data) && data[i] == ' ' {
+			i++
+		}
+		if i == len(data) {
+			return
+		}
+		// end of column test is messy
+		switch {
+		case dashes < 3:
+			// not a valid column
+			return
+
+		case data[i] == '|' && !isBackslashEscaped(data, i):
+			// marker found, now skip past trailing whitespace
+			col++
+			i++
+			for i < len(data) && data[i] == ' ' {
+				i++
+			}
+
+			// trailing junk found after last column
+			if col >= colCount && i < len(data) && data[i] != '\n' {
+				return
+			}
+
+		case (data[i] != '|' || isBackslashEscaped(data, i)) && col+1 < colCount:
+			// something else found where marker was required
+			return
+
+		case data[i] == '\n':
+			// marker is optional for the last column
+			col++
+
+		default:
+			// trailing junk found after last column
+			return
+		}
+	}
+	if col != colCount {
+		return
+	}
+
+	p.addBlock(TableHead, nil)
+	p.tableRow(header, columns, true)
+	size = i
+	if size < len(data) && data[size] == '\n' {
+		size++
+	}
+	return
+}
+
+func (p *Markdown) tableRow(data []byte, columns []CellAlignFlags, header bool) {
+	p.addBlock(TableRow, nil)
+	i, col := 0, 0
+
+	if data[i] == '|' && !isBackslashEscaped(data, i) {
+		i++
+	}
+
+	for col = 0; col < len(columns) && i < len(data); col++ {
+		for i < len(data) && data[i] == ' ' {
+			i++
+		}
+
+		cellStart := i
+
+		for i < len(data) && (data[i] != '|' || isBackslashEscaped(data, i)) && data[i] != '\n' {
+			i++
+		}
+
+		cellEnd := i
+
+		// skip the end-of-cell marker, possibly taking us past end of buffer
+		i++
+
+		for cellEnd > cellStart && cellEnd-1 < len(data) && data[cellEnd-1] == ' ' {
+			cellEnd--
+		}
+
+		cell := p.addBlock(TableCell, data[cellStart:cellEnd])
+		cell.IsHeader = header
+		cell.Align = columns[col]
+	}
+
+	// pad it out with empty columns to get the right number
+	for ; col < len(columns); col++ {
+		cell := p.addBlock(TableCell, nil)
+		cell.IsHeader = header
+		cell.Align = columns[col]
+	}
+
+	// silently ignore rows with too many cells
+}
+
+// returns blockquote prefix length
+func (p *Markdown) quotePrefix(data []byte) int {
+	i := 0
+	for i < 3 && i < len(data) && data[i] == ' ' {
+		i++
+	}
+	if i < len(data) && data[i] == '>' {
+		if i+1 < len(data) && data[i+1] == ' ' {
+			return i + 2
+		}
+		return i + 1
+	}
+	return 0
+}
+
+// blockquote ends with at least one blank line
+// followed by something without a blockquote prefix
+func (p *Markdown) terminateBlockquote(data []byte, beg, end int) bool {
+	if p.isEmpty(data[beg:]) <= 0 {
+		return false
+	}
+	if end >= len(data) {
+		return true
+	}
+	return p.quotePrefix(data[end:]) == 0 && p.isEmpty(data[end:]) == 0
+}
+
+// parse a blockquote fragment
+func (p *Markdown) quote(data []byte) int {
+	block := p.addBlock(BlockQuote, nil)
+	var raw bytes.Buffer
+	beg, end := 0, 0
+	for beg < len(data) {
+		end = beg
+		// Step over whole lines, collecting them. While doing that, check for
+		// fenced code and if one's found, incorporate it altogether,
+		// irregardless of any contents inside it
+		for end < len(data) && data[end] != '\n' {
+			if p.extensions&FencedCode != 0 {
+				if i := p.fencedCodeBlock(data[end:], false); i > 0 {
+					// -1 to compensate for the extra end++ after the loop:
+					end += i - 1
+					break
+				}
+			}
+			end++
+		}
+		if end < len(data) && data[end] == '\n' {
+			end++
+		}
+		if pre := p.quotePrefix(data[beg:]); pre > 0 {
+			// skip the prefix
+			beg += pre
+		} else if p.terminateBlockquote(data, beg, end) {
+			break
+		}
+		// this line is part of the blockquote
+		raw.Write(data[beg:end])
+		beg = end
+	}
+	p.block(raw.Bytes())
+	p.finalize(block)
+	return end
+}
+
+// returns prefix length for block code
+func (p *Markdown) codePrefix(data []byte) int {
+	if len(data) >= 1 && data[0] == '\t' {
+		return 1
+	}
+	if len(data) >= 4 && data[0] == ' ' && data[1] == ' ' && data[2] == ' ' && data[3] == ' ' {
+		return 4
+	}
+	return 0
+}
+
+func (p *Markdown) code(data []byte) int {
+	var work bytes.Buffer
+
+	i := 0
+	for i < len(data) {
+		beg := i
+		for i < len(data) && data[i] != '\n' {
+			i++
+		}
+		if i < len(data) && data[i] == '\n' {
+			i++
+		}
+
+		blankline := p.isEmpty(data[beg:i]) > 0
+		if pre := p.codePrefix(data[beg:i]); pre > 0 {
+			beg += pre
+		} else if !blankline {
+			// non-empty, non-prefixed line breaks the pre
+			i = beg
+			break
+		}
+
+		// verbatim copy to the working buffer
+		if blankline {
+			work.WriteByte('\n')
+		} else {
+			work.Write(data[beg:i])
+		}
+	}
+
+	// trim all the \n off the end of work
+	workbytes := work.Bytes()
+	eol := len(workbytes)
+	for eol > 0 && workbytes[eol-1] == '\n' {
+		eol--
+	}
+	if eol != len(workbytes) {
+		work.Truncate(eol)
+	}
+
+	work.WriteByte('\n')
+
+	block := p.addBlock(CodeBlock, work.Bytes()) // TODO: get rid of temp buffer
+	block.IsFenced = false
+	finalizeCodeBlock(block)
+
+	return i
+}
+
+// returns unordered list item prefix
+func (p *Markdown) uliPrefix(data []byte) int {
+	i := 0
+	// start with up to 3 spaces
+	for i < len(data) && i < 3 && data[i] == ' ' {
+		i++
+	}
+	if i >= len(data)-1 {
+		return 0
+	}
+	// need one of {'*', '+', '-'} followed by a space or a tab
+	if (data[i] != '*' && data[i] != '+' && data[i] != '-') ||
+		(data[i+1] != ' ' && data[i+1] != '\t') {
+		return 0
+	}
+	return i + 2
+}
+
+// returns ordered list item prefix
+func (p *Markdown) oliPrefix(data []byte) int {
+	i := 0
+
+	// start with up to 3 spaces
+	for i < 3 && i < len(data) && data[i] == ' ' {
+		i++
+	}
+
+	// count the digits
+	start := i
+	for i < len(data) && data[i] >= '0' && data[i] <= '9' {
+		i++
+	}
+	if start == i || i >= len(data)-1 {
+		return 0
+	}
+
+	// we need >= 1 digits followed by a dot and a space or a tab
+	if data[i] != '.' || !(data[i+1] == ' ' || data[i+1] == '\t') {
+		return 0
+	}
+	return i + 2
+}
+
+// returns definition list item prefix
+func (p *Markdown) dliPrefix(data []byte) int {
+	if len(data) < 2 {
+		return 0
+	}
+	i := 0
+	// need a ':' followed by a space or a tab
+	if data[i] != ':' || !(data[i+1] == ' ' || data[i+1] == '\t') {
+		return 0
+	}
+	for i < len(data) && data[i] == ' ' {
+		i++
+	}
+	return i + 2
+}
+
+// parse ordered or unordered list block
+func (p *Markdown) list(data []byte, flags ListType) int {
+	i := 0
+	flags |= ListItemBeginningOfList
+	block := p.addBlock(List, nil)
+	block.ListFlags = flags
+	block.Tight = true
+
+	for i < len(data) {
+		skip := p.listItem(data[i:], &flags)
+		if flags&ListItemContainsBlock != 0 {
+			block.ListData.Tight = false
+		}
+		i += skip
+		if skip == 0 || flags&ListItemEndOfList != 0 {
+			break
+		}
+		flags &= ^ListItemBeginningOfList
+	}
+
+	above := block.Parent
+	finalizeList(block)
+	p.tip = above
+	return i
+}
+
+// Returns true if the list item is not the same type as its parent list
+func (p *Markdown) listTypeChanged(data []byte, flags *ListType) bool {
+	if p.dliPrefix(data) > 0 && *flags&ListTypeDefinition == 0 {
+		return true
+	} else if p.oliPrefix(data) > 0 && *flags&ListTypeOrdered == 0 {
+		return true
+	} else if p.uliPrefix(data) > 0 && (*flags&ListTypeOrdered != 0 || *flags&ListTypeDefinition != 0) {
+		return true
+	}
+	return false
+}
+
+// Returns true if block ends with a blank line, descending if needed
+// into lists and sublists.
+func endsWithBlankLine(block *Node) bool {
+	// TODO: figure this out. Always false now.
+	for block != nil {
+		//if block.lastLineBlank {
+		//return true
+		//}
+		t := block.Type
+		if t == List || t == Item {
+			block = block.LastChild
+		} else {
+			break
+		}
+	}
+	return false
+}
+
+func finalizeList(block *Node) {
+	block.open = false
+	item := block.FirstChild
+	for item != nil {
+		// check for non-final list item ending with blank line:
+		if endsWithBlankLine(item) && item.Next != nil {
+			block.ListData.Tight = false
+			break
+		}
+		// recurse into children of list item, to see if there are spaces
+		// between any of them:
+		subItem := item.FirstChild
+		for subItem != nil {
+			if endsWithBlankLine(subItem) && (item.Next != nil || subItem.Next != nil) {
+				block.ListData.Tight = false
+				break
+			}
+			subItem = subItem.Next
+		}
+		item = item.Next
+	}
+}
+
+// Parse a single list item.
+// Assumes initial prefix is already removed if this is a sublist.
+func (p *Markdown) listItem(data []byte, flags *ListType) int {
+	// keep track of the indentation of the first line
+	itemIndent := 0
+	if data[0] == '\t' {
+		itemIndent += 4
+	} else {
+		for itemIndent < 3 && data[itemIndent] == ' ' {
+			itemIndent++
+		}
+	}
+
+	var bulletChar byte = '*'
+	i := p.uliPrefix(data)
+	if i == 0 {
+		i = p.oliPrefix(data)
+	} else {
+		bulletChar = data[i-2]
+	}
+	if i == 0 {
+		i = p.dliPrefix(data)
+		// reset definition term flag
+		if i > 0 {
+			*flags &= ^ListTypeTerm
+		}
+	}
+	if i == 0 {
+		// if in definition list, set term flag and continue
+		if *flags&ListTypeDefinition != 0 {
+			*flags |= ListTypeTerm
+		} else {
+			return 0
+		}
+	}
+
+	// skip leading whitespace on first line
+	for i < len(data) && data[i] == ' ' {
+		i++
+	}
+
+	// find the end of the line
+	line := i
+	for i > 0 && i < len(data) && data[i-1] != '\n' {
+		i++
+	}
+
+	// get working buffer
+	var raw bytes.Buffer
+
+	// put the first line into the working buffer
+	raw.Write(data[line:i])
+	line = i
+
+	// process the following lines
+	containsBlankLine := false
+	sublist := 0
+	codeBlockMarker := ""
+
+gatherlines:
+	for line < len(data) {
+		i++
+
+		// find the end of this line
+		for i < len(data) && data[i-1] != '\n' {
+			i++
+		}
+
+		// if it is an empty line, guess that it is part of this item
+		// and move on to the next line
+		if p.isEmpty(data[line:i]) > 0 {
+			containsBlankLine = true
+			line = i
+			continue
+		}
+
+		// calculate the indentation
+		indent := 0
+		indentIndex := 0
+		if data[line] == '\t' {
+			indentIndex++
+			indent += 4
+		} else {
+			for indent < 4 && line+indent < i && data[line+indent] == ' ' {
+				indent++
+				indentIndex++
+			}
+		}
+
+		chunk := data[line+indentIndex : i]
+
+		if p.extensions&FencedCode != 0 {
+			// determine if in or out of codeblock
+			// if in codeblock, ignore normal list processing
+			_, marker := isFenceLine(chunk, nil, codeBlockMarker)
+			if marker != "" {
+				if codeBlockMarker == "" {
+					// start of codeblock
+					codeBlockMarker = marker
+				} else {
+					// end of codeblock.
+					codeBlockMarker = ""
+				}
+			}
+			// we are in a codeblock, write line, and continue
+			if codeBlockMarker != "" || marker != "" {
+				raw.Write(data[line+indentIndex : i])
+				line = i
+				continue gatherlines
+			}
+		}
+
+		// evaluate how this line fits in
+		switch {
+		// is this a nested list item?
+		case (p.uliPrefix(chunk) > 0 && !p.isHRule(chunk)) ||
+			p.oliPrefix(chunk) > 0 ||
+			p.dliPrefix(chunk) > 0:
+
+			// to be a nested list, it must be indented more
+			// if not, it is either a different kind of list
+			// or the next item in the same list
+			if indent <= itemIndent {
+				if p.listTypeChanged(chunk, flags) {
+					*flags |= ListItemEndOfList
+				} else if containsBlankLine {
+					*flags |= ListItemContainsBlock
+				}
+
+				break gatherlines
+			}
+
+			if containsBlankLine {
+				*flags |= ListItemContainsBlock
+			}
+
+			// is this the first item in the nested list?
+			if sublist == 0 {
+				sublist = raw.Len()
+			}
+
+		// is this a nested prefix heading?
+		case p.isPrefixHeading(chunk):
+			// if the heading is not indented, it is not nested in the list
+			// and thus ends the list
+			if containsBlankLine && indent < 4 {
+				*flags |= ListItemEndOfList
+				break gatherlines
+			}
+			*flags |= ListItemContainsBlock
+
+		// anything following an empty line is only part
+		// of this item if it is indented 4 spaces
+		// (regardless of the indentation of the beginning of the item)
+		case containsBlankLine && indent < 4:
+			if *flags&ListTypeDefinition != 0 && i < len(data)-1 {
+				// is the next item still a part of this list?
+				next := i
+				for next < len(data) && data[next] != '\n' {
+					next++
+				}
+				for next < len(data)-1 && data[next] == '\n' {
+					next++
+				}
+				if i < len(data)-1 && data[i] != ':' && data[next] != ':' {
+					*flags |= ListItemEndOfList
+				}
+			} else {
+				*flags |= ListItemEndOfList
+			}
+			break gatherlines
+
+		// a blank line means this should be parsed as a block
+		case containsBlankLine:
+			raw.WriteByte('\n')
+			*flags |= ListItemContainsBlock
+		}
+
+		// if this line was preceded by one or more blanks,
+		// re-introduce the blank into the buffer
+		if containsBlankLine {
+			containsBlankLine = false
+			raw.WriteByte('\n')
+		}
+
+		// add the line into the working buffer without prefix
+		raw.Write(data[line+indentIndex : i])
+
+		line = i
+	}
+
+	rawBytes := raw.Bytes()
+
+	block := p.addBlock(Item, nil)
+	block.ListFlags = *flags
+	block.Tight = false
+	block.BulletChar = bulletChar
+	block.Delimiter = '.' // Only '.' is possible in Markdown, but ')' will also be possible in CommonMark
+
+	// render the contents of the list item
+	if *flags&ListItemContainsBlock != 0 && *flags&ListTypeTerm == 0 {
+		// intermediate render of block item, except for definition term
+		if sublist > 0 {
+			p.block(rawBytes[:sublist])
+			p.block(rawBytes[sublist:])
+		} else {
+			p.block(rawBytes)
+		}
+	} else {
+		// intermediate render of inline item
+		if sublist > 0 {
+			child := p.addChild(Paragraph, 0)
+			child.content = rawBytes[:sublist]
+			p.block(rawBytes[sublist:])
+		} else {
+			child := p.addChild(Paragraph, 0)
+			child.content = rawBytes
+		}
+	}
+	return line
+}
+
+// render a single paragraph that has already been parsed out
+func (p *Markdown) renderParagraph(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+
+	// trim leading spaces
+	beg := 0
+	for data[beg] == ' ' {
+		beg++
+	}
+
+	end := len(data)
+	// trim trailing newline
+	if data[len(data)-1] == '\n' {
+		end--
+	}
+
+	// trim trailing spaces
+	for end > beg && data[end-1] == ' ' {
+		end--
+	}
+
+	p.addBlock(Paragraph, data[beg:end])
+}
+
+func (p *Markdown) paragraph(data []byte) int {
+	// prev: index of 1st char of previous line
+	// line: index of 1st char of current line
+	// i: index of cursor/end of current line
+	var prev, line, i int
+	tabSize := TabSizeDefault
+	if p.extensions&TabSizeEight != 0 {
+		tabSize = TabSizeDouble
+	}
+	// keep going until we find something to mark the end of the paragraph
+	for i < len(data) {
+		// mark the beginning of the current line
+		prev = line
+		current := data[i:]
+		line = i
+
+		// did we find a reference or a footnote? If so, end a paragraph
+		// preceding it and report that we have consumed up to the end of that
+		// reference:
+		if refEnd := isReference(p, current, tabSize); refEnd > 0 {
+			p.renderParagraph(data[:i])
+			return i + refEnd
+		}
+
+		// did we find a blank line marking the end of the paragraph?
+		if n := p.isEmpty(current); n > 0 {
+			// did this blank line followed by a definition list item?
+			if p.extensions&DefinitionLists != 0 {
+				if i < len(data)-1 && data[i+1] == ':' {
+					return p.list(data[prev:], ListTypeDefinition)
+				}
+			}
+
+			p.renderParagraph(data[:i])
+			return i + n
+		}
+
+		// an underline under some text marks a heading, so our paragraph ended on prev line
+		if i > 0 {
+			if level := p.isUnderlinedHeading(current); level > 0 {
+				// render the paragraph
+				p.renderParagraph(data[:prev])
+
+				// ignore leading and trailing whitespace
+				eol := i - 1
+				for prev < eol && data[prev] == ' ' {
+					prev++
+				}
+				for eol > prev && data[eol-1] == ' ' {
+					eol--
+				}
+
+				id := ""
+				if p.extensions&AutoHeadingIDs != 0 {
+					id = sanitized_anchor_name.Create(string(data[prev:eol]))
+				}
+
+				block := p.addBlock(Heading, data[prev:eol])
+				block.Level = level
+				block.HeadingID = id
+
+				// find the end of the underline
+				for i < len(data) && data[i] != '\n' {
+					i++
+				}
+				return i
+			}
+		}
+
+		// if the next line starts a block of HTML, then the paragraph ends here
+		if p.extensions&LaxHTMLBlocks != 0 {
+			if data[i] == '<' && p.html(current, false) > 0 {
+				// rewind to before the HTML block
+				p.renderParagraph(data[:i])
+				return i
+			}
+		}
+
+		// if there's a prefixed heading or a horizontal rule after this, paragraph is over
+		if p.isPrefixHeading(current) || p.isHRule(current) {
+			p.renderParagraph(data[:i])
+			return i
+		}
+
+		// if there's a fenced code block, paragraph is over
+		if p.extensions&FencedCode != 0 {
+			if p.fencedCodeBlock(current, false) > 0 {
+				p.renderParagraph(data[:i])
+				return i
+			}
+		}
+
+		// if there's a definition list item, prev line is a definition term
+		if p.extensions&DefinitionLists != 0 {
+			if p.dliPrefix(current) != 0 {
+				ret := p.list(data[prev:], ListTypeDefinition)
+				return ret
+			}
+		}
+
+		// if there's a list after this, paragraph is over
+		if p.extensions&NoEmptyLineBeforeBlock != 0 {
+			if p.uliPrefix(current) != 0 ||
+				p.oliPrefix(current) != 0 ||
+				p.quotePrefix(current) != 0 ||
+				p.codePrefix(current) != 0 {
+				p.renderParagraph(data[:i])
+				return i
+			}
+		}
+
+		// otherwise, scan to the beginning of the next line
+		nl := bytes.IndexByte(data[i:], '\n')
+		if nl >= 0 {
+			i += nl + 1
+		} else {
+			i += len(data[i:])
+		}
+	}
+
+	p.renderParagraph(data[:i])
+	return i
+}
+
+func skipChar(data []byte, start int, char byte) int {
+	i := start
+	for i < len(data) && data[i] == char {
+		i++
+	}
+	return i
+}
+
+func skipUntilChar(text []byte, start int, char byte) int {
+	i := start
+	for i < len(text) && text[i] != char {
+		i++
+	}
+	return i
+}

--- a/vendor/github.com/russross/blackfriday/v2/doc.go
+++ b/vendor/github.com/russross/blackfriday/v2/doc.go
@@ -1,0 +1,18 @@
+// Package blackfriday is a markdown processor.
+//
+// It translates plain text with simple formatting rules into an AST, which can
+// then be further processed to HTML (provided by Blackfriday itself) or other
+// formats (provided by the community).
+//
+// The simplest way to invoke Blackfriday is to call the Run function. It will
+// take a text input and produce a text output in HTML (or other format).
+//
+// A slightly more sophisticated way to use Blackfriday is to create a Markdown
+// processor and to call Parse, which returns a syntax tree for the input
+// document. You can leverage Blackfriday's parsing for content extraction from
+// markdown documents. You can assign a custom renderer and set various options
+// to the Markdown processor.
+//
+// If you're interested in calling Blackfriday from command line, see
+// https://github.com/russross/blackfriday-tool.
+package blackfriday

--- a/vendor/github.com/russross/blackfriday/v2/esc.go
+++ b/vendor/github.com/russross/blackfriday/v2/esc.go
@@ -1,0 +1,34 @@
+package blackfriday
+
+import (
+	"html"
+	"io"
+)
+
+var htmlEscaper = [256][]byte{
+	'&': []byte("&amp;"),
+	'<': []byte("&lt;"),
+	'>': []byte("&gt;"),
+	'"': []byte("&quot;"),
+}
+
+func escapeHTML(w io.Writer, s []byte) {
+	var start, end int
+	for end < len(s) {
+		escSeq := htmlEscaper[s[end]]
+		if escSeq != nil {
+			w.Write(s[start:end])
+			w.Write(escSeq)
+			start = end + 1
+		}
+		end++
+	}
+	if start < len(s) && end <= len(s) {
+		w.Write(s[start:end])
+	}
+}
+
+func escLink(w io.Writer, text []byte) {
+	unesc := html.UnescapeString(string(text))
+	escapeHTML(w, []byte(unesc))
+}

--- a/vendor/github.com/russross/blackfriday/v2/html.go
+++ b/vendor/github.com/russross/blackfriday/v2/html.go
@@ -1,0 +1,949 @@
+//
+// Blackfriday Markdown Processor
+// Available at http://github.com/russross/blackfriday
+//
+// Copyright © 2011 Russ Ross <russ@russross.com>.
+// Distributed under the Simplified BSD License.
+// See README.md for details.
+//
+
+//
+//
+// HTML rendering backend
+//
+//
+
+package blackfriday
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// HTMLFlags control optional behavior of HTML renderer.
+type HTMLFlags int
+
+// HTML renderer configuration options.
+const (
+	HTMLFlagsNone           HTMLFlags = 0
+	SkipHTML                HTMLFlags = 1 << iota // Skip preformatted HTML blocks
+	SkipImages                                    // Skip embedded images
+	SkipLinks                                     // Skip all links
+	Safelink                                      // Only link to trusted protocols
+	NofollowLinks                                 // Only link with rel="nofollow"
+	NoreferrerLinks                               // Only link with rel="noreferrer"
+	NoopenerLinks                                 // Only link with rel="noopener"
+	HrefTargetBlank                               // Add a blank target
+	CompletePage                                  // Generate a complete HTML page
+	UseXHTML                                      // Generate XHTML output instead of HTML
+	FootnoteReturnLinks                           // Generate a link at the end of a footnote to return to the source
+	Smartypants                                   // Enable smart punctuation substitutions
+	SmartypantsFractions                          // Enable smart fractions (with Smartypants)
+	SmartypantsDashes                             // Enable smart dashes (with Smartypants)
+	SmartypantsLatexDashes                        // Enable LaTeX-style dashes (with Smartypants)
+	SmartypantsAngledQuotes                       // Enable angled double quotes (with Smartypants) for double quotes rendering
+	SmartypantsQuotesNBSP                         // Enable « French guillemets » (with Smartypants)
+	TOC                                           // Generate a table of contents
+)
+
+var (
+	htmlTagRe = regexp.MustCompile("(?i)^" + htmlTag)
+)
+
+const (
+	htmlTag = "(?:" + openTag + "|" + closeTag + "|" + htmlComment + "|" +
+		processingInstruction + "|" + declaration + "|" + cdata + ")"
+	closeTag              = "</" + tagName + "\\s*[>]"
+	openTag               = "<" + tagName + attribute + "*" + "\\s*/?>"
+	attribute             = "(?:" + "\\s+" + attributeName + attributeValueSpec + "?)"
+	attributeValue        = "(?:" + unquotedValue + "|" + singleQuotedValue + "|" + doubleQuotedValue + ")"
+	attributeValueSpec    = "(?:" + "\\s*=" + "\\s*" + attributeValue + ")"
+	attributeName         = "[a-zA-Z_:][a-zA-Z0-9:._-]*"
+	cdata                 = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>"
+	declaration           = "<![A-Z]+" + "\\s+[^>]*>"
+	doubleQuotedValue     = "\"[^\"]*\""
+	htmlComment           = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->"
+	processingInstruction = "[<][?].*?[?][>]"
+	singleQuotedValue     = "'[^']*'"
+	tagName               = "[A-Za-z][A-Za-z0-9-]*"
+	unquotedValue         = "[^\"'=<>`\\x00-\\x20]+"
+)
+
+// HTMLRendererParameters is a collection of supplementary parameters tweaking
+// the behavior of various parts of HTML renderer.
+type HTMLRendererParameters struct {
+	// Prepend this text to each relative URL.
+	AbsolutePrefix string
+	// Add this text to each footnote anchor, to ensure uniqueness.
+	FootnoteAnchorPrefix string
+	// Show this text inside the <a> tag for a footnote return link, if the
+	// HTML_FOOTNOTE_RETURN_LINKS flag is enabled. If blank, the string
+	// <sup>[return]</sup> is used.
+	FootnoteReturnLinkContents string
+	// If set, add this text to the front of each Heading ID, to ensure
+	// uniqueness.
+	HeadingIDPrefix string
+	// If set, add this text to the back of each Heading ID, to ensure uniqueness.
+	HeadingIDSuffix string
+	// Increase heading levels: if the offset is 1, <h1> becomes <h2> etc.
+	// Negative offset is also valid.
+	// Resulting levels are clipped between 1 and 6.
+	HeadingLevelOffset int
+
+	Title string // Document title (used if CompletePage is set)
+	CSS   string // Optional CSS file URL (used if CompletePage is set)
+	Icon  string // Optional icon file URL (used if CompletePage is set)
+
+	Flags HTMLFlags // Flags allow customizing this renderer's behavior
+}
+
+// HTMLRenderer is a type that implements the Renderer interface for HTML output.
+//
+// Do not create this directly, instead use the NewHTMLRenderer function.
+type HTMLRenderer struct {
+	HTMLRendererParameters
+
+	closeTag string // how to end singleton tags: either " />" or ">"
+
+	// Track heading IDs to prevent ID collision in a single generation.
+	headingIDs map[string]int
+
+	lastOutputLen int
+	disableTags   int
+
+	sr *SPRenderer
+}
+
+const (
+	xhtmlClose = " />"
+	htmlClose  = ">"
+)
+
+// NewHTMLRenderer creates and configures an HTMLRenderer object, which
+// satisfies the Renderer interface.
+func NewHTMLRenderer(params HTMLRendererParameters) *HTMLRenderer {
+	// configure the rendering engine
+	closeTag := htmlClose
+	if params.Flags&UseXHTML != 0 {
+		closeTag = xhtmlClose
+	}
+
+	if params.FootnoteReturnLinkContents == "" {
+		params.FootnoteReturnLinkContents = `<sup>[return]</sup>`
+	}
+
+	return &HTMLRenderer{
+		HTMLRendererParameters: params,
+
+		closeTag:   closeTag,
+		headingIDs: make(map[string]int),
+
+		sr: NewSmartypantsRenderer(params.Flags),
+	}
+}
+
+func isHTMLTag(tag []byte, tagname string) bool {
+	found, _ := findHTMLTagPos(tag, tagname)
+	return found
+}
+
+// Look for a character, but ignore it when it's in any kind of quotes, it
+// might be JavaScript
+func skipUntilCharIgnoreQuotes(html []byte, start int, char byte) int {
+	inSingleQuote := false
+	inDoubleQuote := false
+	inGraveQuote := false
+	i := start
+	for i < len(html) {
+		switch {
+		case html[i] == char && !inSingleQuote && !inDoubleQuote && !inGraveQuote:
+			return i
+		case html[i] == '\'':
+			inSingleQuote = !inSingleQuote
+		case html[i] == '"':
+			inDoubleQuote = !inDoubleQuote
+		case html[i] == '`':
+			inGraveQuote = !inGraveQuote
+		}
+		i++
+	}
+	return start
+}
+
+func findHTMLTagPos(tag []byte, tagname string) (bool, int) {
+	i := 0
+	if i < len(tag) && tag[0] != '<' {
+		return false, -1
+	}
+	i++
+	i = skipSpace(tag, i)
+
+	if i < len(tag) && tag[i] == '/' {
+		i++
+	}
+
+	i = skipSpace(tag, i)
+	j := 0
+	for ; i < len(tag); i, j = i+1, j+1 {
+		if j >= len(tagname) {
+			break
+		}
+
+		if strings.ToLower(string(tag[i]))[0] != tagname[j] {
+			return false, -1
+		}
+	}
+
+	if i == len(tag) {
+		return false, -1
+	}
+
+	rightAngle := skipUntilCharIgnoreQuotes(tag, i, '>')
+	if rightAngle >= i {
+		return true, rightAngle
+	}
+
+	return false, -1
+}
+
+func skipSpace(tag []byte, i int) int {
+	for i < len(tag) && isspace(tag[i]) {
+		i++
+	}
+	return i
+}
+
+func isRelativeLink(link []byte) (yes bool) {
+	// a tag begin with '#'
+	if link[0] == '#' {
+		return true
+	}
+
+	// link begin with '/' but not '//', the second maybe a protocol relative link
+	if len(link) >= 2 && link[0] == '/' && link[1] != '/' {
+		return true
+	}
+
+	// only the root '/'
+	if len(link) == 1 && link[0] == '/' {
+		return true
+	}
+
+	// current directory : begin with "./"
+	if bytes.HasPrefix(link, []byte("./")) {
+		return true
+	}
+
+	// parent directory : begin with "../"
+	if bytes.HasPrefix(link, []byte("../")) {
+		return true
+	}
+
+	return false
+}
+
+func (r *HTMLRenderer) ensureUniqueHeadingID(id string) string {
+	for count, found := r.headingIDs[id]; found; count, found = r.headingIDs[id] {
+		tmp := fmt.Sprintf("%s-%d", id, count+1)
+
+		if _, tmpFound := r.headingIDs[tmp]; !tmpFound {
+			r.headingIDs[id] = count + 1
+			id = tmp
+		} else {
+			id = id + "-1"
+		}
+	}
+
+	if _, found := r.headingIDs[id]; !found {
+		r.headingIDs[id] = 0
+	}
+
+	return id
+}
+
+func (r *HTMLRenderer) addAbsPrefix(link []byte) []byte {
+	if r.AbsolutePrefix != "" && isRelativeLink(link) && link[0] != '.' {
+		newDest := r.AbsolutePrefix
+		if link[0] != '/' {
+			newDest += "/"
+		}
+		newDest += string(link)
+		return []byte(newDest)
+	}
+	return link
+}
+
+func appendLinkAttrs(attrs []string, flags HTMLFlags, link []byte) []string {
+	if isRelativeLink(link) {
+		return attrs
+	}
+	val := []string{}
+	if flags&NofollowLinks != 0 {
+		val = append(val, "nofollow")
+	}
+	if flags&NoreferrerLinks != 0 {
+		val = append(val, "noreferrer")
+	}
+	if flags&NoopenerLinks != 0 {
+		val = append(val, "noopener")
+	}
+	if flags&HrefTargetBlank != 0 {
+		attrs = append(attrs, "target=\"_blank\"")
+	}
+	if len(val) == 0 {
+		return attrs
+	}
+	attr := fmt.Sprintf("rel=%q", strings.Join(val, " "))
+	return append(attrs, attr)
+}
+
+func isMailto(link []byte) bool {
+	return bytes.HasPrefix(link, []byte("mailto:"))
+}
+
+func needSkipLink(flags HTMLFlags, dest []byte) bool {
+	if flags&SkipLinks != 0 {
+		return true
+	}
+	return flags&Safelink != 0 && !isSafeLink(dest) && !isMailto(dest)
+}
+
+func isSmartypantable(node *Node) bool {
+	pt := node.Parent.Type
+	return pt != Link && pt != CodeBlock && pt != Code
+}
+
+func appendLanguageAttr(attrs []string, info []byte) []string {
+	if len(info) == 0 {
+		return attrs
+	}
+	endOfLang := bytes.IndexAny(info, "\t ")
+	if endOfLang < 0 {
+		endOfLang = len(info)
+	}
+	return append(attrs, fmt.Sprintf("class=\"language-%s\"", info[:endOfLang]))
+}
+
+func (r *HTMLRenderer) tag(w io.Writer, name []byte, attrs []string) {
+	w.Write(name)
+	if len(attrs) > 0 {
+		w.Write(spaceBytes)
+		w.Write([]byte(strings.Join(attrs, " ")))
+	}
+	w.Write(gtBytes)
+	r.lastOutputLen = 1
+}
+
+func footnoteRef(prefix string, node *Node) []byte {
+	urlFrag := prefix + string(slugify(node.Destination))
+	anchor := fmt.Sprintf(`<a href="#fn:%s">%d</a>`, urlFrag, node.NoteID)
+	return []byte(fmt.Sprintf(`<sup class="footnote-ref" id="fnref:%s">%s</sup>`, urlFrag, anchor))
+}
+
+func footnoteItem(prefix string, slug []byte) []byte {
+	return []byte(fmt.Sprintf(`<li id="fn:%s%s">`, prefix, slug))
+}
+
+func footnoteReturnLink(prefix, returnLink string, slug []byte) []byte {
+	const format = ` <a class="footnote-return" href="#fnref:%s%s">%s</a>`
+	return []byte(fmt.Sprintf(format, prefix, slug, returnLink))
+}
+
+func itemOpenCR(node *Node) bool {
+	if node.Prev == nil {
+		return false
+	}
+	ld := node.Parent.ListData
+	return !ld.Tight && ld.ListFlags&ListTypeDefinition == 0
+}
+
+func skipParagraphTags(node *Node) bool {
+	grandparent := node.Parent.Parent
+	if grandparent == nil || grandparent.Type != List {
+		return false
+	}
+	tightOrTerm := grandparent.Tight || node.Parent.ListFlags&ListTypeTerm != 0
+	return grandparent.Type == List && tightOrTerm
+}
+
+func cellAlignment(align CellAlignFlags) string {
+	switch align {
+	case TableAlignmentLeft:
+		return "left"
+	case TableAlignmentRight:
+		return "right"
+	case TableAlignmentCenter:
+		return "center"
+	default:
+		return ""
+	}
+}
+
+func (r *HTMLRenderer) out(w io.Writer, text []byte) {
+	if r.disableTags > 0 {
+		w.Write(htmlTagRe.ReplaceAll(text, []byte{}))
+	} else {
+		w.Write(text)
+	}
+	r.lastOutputLen = len(text)
+}
+
+func (r *HTMLRenderer) cr(w io.Writer) {
+	if r.lastOutputLen > 0 {
+		r.out(w, nlBytes)
+	}
+}
+
+var (
+	nlBytes    = []byte{'\n'}
+	gtBytes    = []byte{'>'}
+	spaceBytes = []byte{' '}
+)
+
+var (
+	brTag              = []byte("<br>")
+	brXHTMLTag         = []byte("<br />")
+	emTag              = []byte("<em>")
+	emCloseTag         = []byte("</em>")
+	strongTag          = []byte("<strong>")
+	strongCloseTag     = []byte("</strong>")
+	delTag             = []byte("<del>")
+	delCloseTag        = []byte("</del>")
+	ttTag              = []byte("<tt>")
+	ttCloseTag         = []byte("</tt>")
+	aTag               = []byte("<a")
+	aCloseTag          = []byte("</a>")
+	preTag             = []byte("<pre>")
+	preCloseTag        = []byte("</pre>")
+	codeTag            = []byte("<code>")
+	codeCloseTag       = []byte("</code>")
+	pTag               = []byte("<p>")
+	pCloseTag          = []byte("</p>")
+	blockquoteTag      = []byte("<blockquote>")
+	blockquoteCloseTag = []byte("</blockquote>")
+	hrTag              = []byte("<hr>")
+	hrXHTMLTag         = []byte("<hr />")
+	ulTag              = []byte("<ul>")
+	ulCloseTag         = []byte("</ul>")
+	olTag              = []byte("<ol>")
+	olCloseTag         = []byte("</ol>")
+	dlTag              = []byte("<dl>")
+	dlCloseTag         = []byte("</dl>")
+	liTag              = []byte("<li>")
+	liCloseTag         = []byte("</li>")
+	ddTag              = []byte("<dd>")
+	ddCloseTag         = []byte("</dd>")
+	dtTag              = []byte("<dt>")
+	dtCloseTag         = []byte("</dt>")
+	tableTag           = []byte("<table>")
+	tableCloseTag      = []byte("</table>")
+	tdTag              = []byte("<td")
+	tdCloseTag         = []byte("</td>")
+	thTag              = []byte("<th")
+	thCloseTag         = []byte("</th>")
+	theadTag           = []byte("<thead>")
+	theadCloseTag      = []byte("</thead>")
+	tbodyTag           = []byte("<tbody>")
+	tbodyCloseTag      = []byte("</tbody>")
+	trTag              = []byte("<tr>")
+	trCloseTag         = []byte("</tr>")
+	h1Tag              = []byte("<h1")
+	h1CloseTag         = []byte("</h1>")
+	h2Tag              = []byte("<h2")
+	h2CloseTag         = []byte("</h2>")
+	h3Tag              = []byte("<h3")
+	h3CloseTag         = []byte("</h3>")
+	h4Tag              = []byte("<h4")
+	h4CloseTag         = []byte("</h4>")
+	h5Tag              = []byte("<h5")
+	h5CloseTag         = []byte("</h5>")
+	h6Tag              = []byte("<h6")
+	h6CloseTag         = []byte("</h6>")
+
+	footnotesDivBytes      = []byte("\n<div class=\"footnotes\">\n\n")
+	footnotesCloseDivBytes = []byte("\n</div>\n")
+)
+
+func headingTagsFromLevel(level int) ([]byte, []byte) {
+	if level <= 1 {
+		return h1Tag, h1CloseTag
+	}
+	switch level {
+	case 2:
+		return h2Tag, h2CloseTag
+	case 3:
+		return h3Tag, h3CloseTag
+	case 4:
+		return h4Tag, h4CloseTag
+	case 5:
+		return h5Tag, h5CloseTag
+	}
+	return h6Tag, h6CloseTag
+}
+
+func (r *HTMLRenderer) outHRTag(w io.Writer) {
+	if r.Flags&UseXHTML == 0 {
+		r.out(w, hrTag)
+	} else {
+		r.out(w, hrXHTMLTag)
+	}
+}
+
+// RenderNode is a default renderer of a single node of a syntax tree. For
+// block nodes it will be called twice: first time with entering=true, second
+// time with entering=false, so that it could know when it's working on an open
+// tag and when on close. It writes the result to w.
+//
+// The return value is a way to tell the calling walker to adjust its walk
+// pattern: e.g. it can terminate the traversal by returning Terminate. Or it
+// can ask the walker to skip a subtree of this node by returning SkipChildren.
+// The typical behavior is to return GoToNext, which asks for the usual
+// traversal to the next node.
+func (r *HTMLRenderer) RenderNode(w io.Writer, node *Node, entering bool) WalkStatus {
+	attrs := []string{}
+	switch node.Type {
+	case Text:
+		if r.Flags&Smartypants != 0 {
+			var tmp bytes.Buffer
+			escapeHTML(&tmp, node.Literal)
+			r.sr.Process(w, tmp.Bytes())
+		} else {
+			if node.Parent.Type == Link {
+				escLink(w, node.Literal)
+			} else {
+				escapeHTML(w, node.Literal)
+			}
+		}
+	case Softbreak:
+		r.cr(w)
+		// TODO: make it configurable via out(renderer.softbreak)
+	case Hardbreak:
+		if r.Flags&UseXHTML == 0 {
+			r.out(w, brTag)
+		} else {
+			r.out(w, brXHTMLTag)
+		}
+		r.cr(w)
+	case Emph:
+		if entering {
+			r.out(w, emTag)
+		} else {
+			r.out(w, emCloseTag)
+		}
+	case Strong:
+		if entering {
+			r.out(w, strongTag)
+		} else {
+			r.out(w, strongCloseTag)
+		}
+	case Del:
+		if entering {
+			r.out(w, delTag)
+		} else {
+			r.out(w, delCloseTag)
+		}
+	case HTMLSpan:
+		if r.Flags&SkipHTML != 0 {
+			break
+		}
+		r.out(w, node.Literal)
+	case Link:
+		// mark it but don't link it if it is not a safe link: no smartypants
+		dest := node.LinkData.Destination
+		if needSkipLink(r.Flags, dest) {
+			if entering {
+				r.out(w, ttTag)
+			} else {
+				r.out(w, ttCloseTag)
+			}
+		} else {
+			if entering {
+				dest = r.addAbsPrefix(dest)
+				var hrefBuf bytes.Buffer
+				hrefBuf.WriteString("href=\"")
+				escLink(&hrefBuf, dest)
+				hrefBuf.WriteByte('"')
+				attrs = append(attrs, hrefBuf.String())
+				if node.NoteID != 0 {
+					r.out(w, footnoteRef(r.FootnoteAnchorPrefix, node))
+					break
+				}
+				attrs = appendLinkAttrs(attrs, r.Flags, dest)
+				if len(node.LinkData.Title) > 0 {
+					var titleBuff bytes.Buffer
+					titleBuff.WriteString("title=\"")
+					escapeHTML(&titleBuff, node.LinkData.Title)
+					titleBuff.WriteByte('"')
+					attrs = append(attrs, titleBuff.String())
+				}
+				r.tag(w, aTag, attrs)
+			} else {
+				if node.NoteID != 0 {
+					break
+				}
+				r.out(w, aCloseTag)
+			}
+		}
+	case Image:
+		if r.Flags&SkipImages != 0 {
+			return SkipChildren
+		}
+		if entering {
+			dest := node.LinkData.Destination
+			dest = r.addAbsPrefix(dest)
+			if r.disableTags == 0 {
+				//if options.safe && potentiallyUnsafe(dest) {
+				//out(w, `<img src="" alt="`)
+				//} else {
+				r.out(w, []byte(`<img src="`))
+				escLink(w, dest)
+				r.out(w, []byte(`" alt="`))
+				//}
+			}
+			r.disableTags++
+		} else {
+			r.disableTags--
+			if r.disableTags == 0 {
+				if node.LinkData.Title != nil {
+					r.out(w, []byte(`" title="`))
+					escapeHTML(w, node.LinkData.Title)
+				}
+				r.out(w, []byte(`" />`))
+			}
+		}
+	case Code:
+		r.out(w, codeTag)
+		escapeHTML(w, node.Literal)
+		r.out(w, codeCloseTag)
+	case Document:
+		break
+	case Paragraph:
+		if skipParagraphTags(node) {
+			break
+		}
+		if entering {
+			// TODO: untangle this clusterfuck about when the newlines need
+			// to be added and when not.
+			if node.Prev != nil {
+				switch node.Prev.Type {
+				case HTMLBlock, List, Paragraph, Heading, CodeBlock, BlockQuote, HorizontalRule:
+					r.cr(w)
+				}
+			}
+			if node.Parent.Type == BlockQuote && node.Prev == nil {
+				r.cr(w)
+			}
+			r.out(w, pTag)
+		} else {
+			r.out(w, pCloseTag)
+			if !(node.Parent.Type == Item && node.Next == nil) {
+				r.cr(w)
+			}
+		}
+	case BlockQuote:
+		if entering {
+			r.cr(w)
+			r.out(w, blockquoteTag)
+		} else {
+			r.out(w, blockquoteCloseTag)
+			r.cr(w)
+		}
+	case HTMLBlock:
+		if r.Flags&SkipHTML != 0 {
+			break
+		}
+		r.cr(w)
+		r.out(w, node.Literal)
+		r.cr(w)
+	case Heading:
+		headingLevel := r.HTMLRendererParameters.HeadingLevelOffset + node.Level
+		openTag, closeTag := headingTagsFromLevel(headingLevel)
+		if entering {
+			if node.IsTitleblock {
+				attrs = append(attrs, `class="title"`)
+			}
+			if node.HeadingID != "" {
+				id := r.ensureUniqueHeadingID(node.HeadingID)
+				if r.HeadingIDPrefix != "" {
+					id = r.HeadingIDPrefix + id
+				}
+				if r.HeadingIDSuffix != "" {
+					id = id + r.HeadingIDSuffix
+				}
+				attrs = append(attrs, fmt.Sprintf(`id="%s"`, id))
+			}
+			r.cr(w)
+			r.tag(w, openTag, attrs)
+		} else {
+			r.out(w, closeTag)
+			if !(node.Parent.Type == Item && node.Next == nil) {
+				r.cr(w)
+			}
+		}
+	case HorizontalRule:
+		r.cr(w)
+		r.outHRTag(w)
+		r.cr(w)
+	case List:
+		openTag := ulTag
+		closeTag := ulCloseTag
+		if node.ListFlags&ListTypeOrdered != 0 {
+			openTag = olTag
+			closeTag = olCloseTag
+		}
+		if node.ListFlags&ListTypeDefinition != 0 {
+			openTag = dlTag
+			closeTag = dlCloseTag
+		}
+		if entering {
+			if node.IsFootnotesList {
+				r.out(w, footnotesDivBytes)
+				r.outHRTag(w)
+				r.cr(w)
+			}
+			r.cr(w)
+			if node.Parent.Type == Item && node.Parent.Parent.Tight {
+				r.cr(w)
+			}
+			r.tag(w, openTag[:len(openTag)-1], attrs)
+			r.cr(w)
+		} else {
+			r.out(w, closeTag)
+			//cr(w)
+			//if node.parent.Type != Item {
+			//	cr(w)
+			//}
+			if node.Parent.Type == Item && node.Next != nil {
+				r.cr(w)
+			}
+			if node.Parent.Type == Document || node.Parent.Type == BlockQuote {
+				r.cr(w)
+			}
+			if node.IsFootnotesList {
+				r.out(w, footnotesCloseDivBytes)
+			}
+		}
+	case Item:
+		openTag := liTag
+		closeTag := liCloseTag
+		if node.ListFlags&ListTypeDefinition != 0 {
+			openTag = ddTag
+			closeTag = ddCloseTag
+		}
+		if node.ListFlags&ListTypeTerm != 0 {
+			openTag = dtTag
+			closeTag = dtCloseTag
+		}
+		if entering {
+			if itemOpenCR(node) {
+				r.cr(w)
+			}
+			if node.ListData.RefLink != nil {
+				slug := slugify(node.ListData.RefLink)
+				r.out(w, footnoteItem(r.FootnoteAnchorPrefix, slug))
+				break
+			}
+			r.out(w, openTag)
+		} else {
+			if node.ListData.RefLink != nil {
+				slug := slugify(node.ListData.RefLink)
+				if r.Flags&FootnoteReturnLinks != 0 {
+					r.out(w, footnoteReturnLink(r.FootnoteAnchorPrefix, r.FootnoteReturnLinkContents, slug))
+				}
+			}
+			r.out(w, closeTag)
+			r.cr(w)
+		}
+	case CodeBlock:
+		attrs = appendLanguageAttr(attrs, node.Info)
+		r.cr(w)
+		r.out(w, preTag)
+		r.tag(w, codeTag[:len(codeTag)-1], attrs)
+		escapeHTML(w, node.Literal)
+		r.out(w, codeCloseTag)
+		r.out(w, preCloseTag)
+		if node.Parent.Type != Item {
+			r.cr(w)
+		}
+	case Table:
+		if entering {
+			r.cr(w)
+			r.out(w, tableTag)
+		} else {
+			r.out(w, tableCloseTag)
+			r.cr(w)
+		}
+	case TableCell:
+		openTag := tdTag
+		closeTag := tdCloseTag
+		if node.IsHeader {
+			openTag = thTag
+			closeTag = thCloseTag
+		}
+		if entering {
+			align := cellAlignment(node.Align)
+			if align != "" {
+				attrs = append(attrs, fmt.Sprintf(`align="%s"`, align))
+			}
+			if node.Prev == nil {
+				r.cr(w)
+			}
+			r.tag(w, openTag, attrs)
+		} else {
+			r.out(w, closeTag)
+			r.cr(w)
+		}
+	case TableHead:
+		if entering {
+			r.cr(w)
+			r.out(w, theadTag)
+		} else {
+			r.out(w, theadCloseTag)
+			r.cr(w)
+		}
+	case TableBody:
+		if entering {
+			r.cr(w)
+			r.out(w, tbodyTag)
+			// XXX: this is to adhere to a rather silly test. Should fix test.
+			if node.FirstChild == nil {
+				r.cr(w)
+			}
+		} else {
+			r.out(w, tbodyCloseTag)
+			r.cr(w)
+		}
+	case TableRow:
+		if entering {
+			r.cr(w)
+			r.out(w, trTag)
+		} else {
+			r.out(w, trCloseTag)
+			r.cr(w)
+		}
+	default:
+		panic("Unknown node type " + node.Type.String())
+	}
+	return GoToNext
+}
+
+// RenderHeader writes HTML document preamble and TOC if requested.
+func (r *HTMLRenderer) RenderHeader(w io.Writer, ast *Node) {
+	r.writeDocumentHeader(w)
+	if r.Flags&TOC != 0 {
+		r.writeTOC(w, ast)
+	}
+}
+
+// RenderFooter writes HTML document footer.
+func (r *HTMLRenderer) RenderFooter(w io.Writer, ast *Node) {
+	if r.Flags&CompletePage == 0 {
+		return
+	}
+	io.WriteString(w, "\n</body>\n</html>\n")
+}
+
+func (r *HTMLRenderer) writeDocumentHeader(w io.Writer) {
+	if r.Flags&CompletePage == 0 {
+		return
+	}
+	ending := ""
+	if r.Flags&UseXHTML != 0 {
+		io.WriteString(w, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" ")
+		io.WriteString(w, "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n")
+		io.WriteString(w, "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n")
+		ending = " /"
+	} else {
+		io.WriteString(w, "<!DOCTYPE html>\n")
+		io.WriteString(w, "<html>\n")
+	}
+	io.WriteString(w, "<head>\n")
+	io.WriteString(w, "  <title>")
+	if r.Flags&Smartypants != 0 {
+		r.sr.Process(w, []byte(r.Title))
+	} else {
+		escapeHTML(w, []byte(r.Title))
+	}
+	io.WriteString(w, "</title>\n")
+	io.WriteString(w, "  <meta name=\"GENERATOR\" content=\"Blackfriday Markdown Processor v")
+	io.WriteString(w, Version)
+	io.WriteString(w, "\"")
+	io.WriteString(w, ending)
+	io.WriteString(w, ">\n")
+	io.WriteString(w, "  <meta charset=\"utf-8\"")
+	io.WriteString(w, ending)
+	io.WriteString(w, ">\n")
+	if r.CSS != "" {
+		io.WriteString(w, "  <link rel=\"stylesheet\" type=\"text/css\" href=\"")
+		escapeHTML(w, []byte(r.CSS))
+		io.WriteString(w, "\"")
+		io.WriteString(w, ending)
+		io.WriteString(w, ">\n")
+	}
+	if r.Icon != "" {
+		io.WriteString(w, "  <link rel=\"icon\" type=\"image/x-icon\" href=\"")
+		escapeHTML(w, []byte(r.Icon))
+		io.WriteString(w, "\"")
+		io.WriteString(w, ending)
+		io.WriteString(w, ">\n")
+	}
+	io.WriteString(w, "</head>\n")
+	io.WriteString(w, "<body>\n\n")
+}
+
+func (r *HTMLRenderer) writeTOC(w io.Writer, ast *Node) {
+	buf := bytes.Buffer{}
+
+	inHeading := false
+	tocLevel := 0
+	headingCount := 0
+
+	ast.Walk(func(node *Node, entering bool) WalkStatus {
+		if node.Type == Heading && !node.HeadingData.IsTitleblock {
+			inHeading = entering
+			if entering {
+				node.HeadingID = fmt.Sprintf("toc_%d", headingCount)
+				if node.Level == tocLevel {
+					buf.WriteString("</li>\n\n<li>")
+				} else if node.Level < tocLevel {
+					for node.Level < tocLevel {
+						tocLevel--
+						buf.WriteString("</li>\n</ul>")
+					}
+					buf.WriteString("</li>\n\n<li>")
+				} else {
+					for node.Level > tocLevel {
+						tocLevel++
+						buf.WriteString("\n<ul>\n<li>")
+					}
+				}
+
+				fmt.Fprintf(&buf, `<a href="#toc_%d">`, headingCount)
+				headingCount++
+			} else {
+				buf.WriteString("</a>")
+			}
+			return GoToNext
+		}
+
+		if inHeading {
+			return r.RenderNode(&buf, node, entering)
+		}
+
+		return GoToNext
+	})
+
+	for ; tocLevel > 0; tocLevel-- {
+		buf.WriteString("</li>\n</ul>")
+	}
+
+	if buf.Len() > 0 {
+		io.WriteString(w, "<nav>\n")
+		w.Write(buf.Bytes())
+		io.WriteString(w, "\n\n</nav>\n")
+	}
+	r.lastOutputLen = buf.Len()
+}

--- a/vendor/github.com/russross/blackfriday/v2/inline.go
+++ b/vendor/github.com/russross/blackfriday/v2/inline.go
@@ -1,0 +1,1228 @@
+//
+// Blackfriday Markdown Processor
+// Available at http://github.com/russross/blackfriday
+//
+// Copyright © 2011 Russ Ross <russ@russross.com>.
+// Distributed under the Simplified BSD License.
+// See README.md for details.
+//
+
+//
+// Functions to parse inline elements.
+//
+
+package blackfriday
+
+import (
+	"bytes"
+	"regexp"
+	"strconv"
+)
+
+var (
+	urlRe    = `((https?|ftp):\/\/|\/)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)]+`
+	anchorRe = regexp.MustCompile(`^(<a\shref="` + urlRe + `"(\stitle="[^"<>]+")?\s?>` + urlRe + `<\/a>)`)
+
+	// https://www.w3.org/TR/html5/syntax.html#character-references
+	// highest unicode code point in 17 planes (2^20): 1,114,112d =
+	// 7 dec digits or 6 hex digits
+	// named entity references can be 2-31 characters with stuff like &lt;
+	// at one end and &CounterClockwiseContourIntegral; at the other. There
+	// are also sometimes numbers at the end, although this isn't inherent
+	// in the specification; there are never numbers anywhere else in
+	// current character references, though; see &frac34; and &blk12;, etc.
+	// https://www.w3.org/TR/html5/syntax.html#named-character-references
+	//
+	// entity := "&" (named group | number ref) ";"
+	// named group := [a-zA-Z]{2,31}[0-9]{0,2}
+	// number ref := "#" (dec ref | hex ref)
+	// dec ref := [0-9]{1,7}
+	// hex ref := ("x" | "X") [0-9a-fA-F]{1,6}
+	htmlEntityRe = regexp.MustCompile(`&([a-zA-Z]{2,31}[0-9]{0,2}|#([0-9]{1,7}|[xX][0-9a-fA-F]{1,6}));`)
+)
+
+// Functions to parse text within a block
+// Each function returns the number of chars taken care of
+// data is the complete block being rendered
+// offset is the number of valid chars before the current cursor
+
+func (p *Markdown) inline(currBlock *Node, data []byte) {
+	// handlers might call us recursively: enforce a maximum depth
+	if p.nesting >= p.maxNesting || len(data) == 0 {
+		return
+	}
+	p.nesting++
+	beg, end := 0, 0
+	for end < len(data) {
+		handler := p.inlineCallback[data[end]]
+		if handler != nil {
+			if consumed, node := handler(p, data, end); consumed == 0 {
+				// No action from the callback.
+				end++
+			} else {
+				// Copy inactive chars into the output.
+				currBlock.AppendChild(text(data[beg:end]))
+				if node != nil {
+					currBlock.AppendChild(node)
+				}
+				// Skip past whatever the callback used.
+				beg = end + consumed
+				end = beg
+			}
+		} else {
+			end++
+		}
+	}
+	if beg < len(data) {
+		if data[end-1] == '\n' {
+			end--
+		}
+		currBlock.AppendChild(text(data[beg:end]))
+	}
+	p.nesting--
+}
+
+// single and double emphasis parsing
+func emphasis(p *Markdown, data []byte, offset int) (int, *Node) {
+	data = data[offset:]
+	c := data[0]
+
+	if len(data) > 2 && data[1] != c {
+		// whitespace cannot follow an opening emphasis;
+		// strikethrough only takes two characters '~~'
+		if c == '~' || isspace(data[1]) {
+			return 0, nil
+		}
+		ret, node := helperEmphasis(p, data[1:], c)
+		if ret == 0 {
+			return 0, nil
+		}
+
+		return ret + 1, node
+	}
+
+	if len(data) > 3 && data[1] == c && data[2] != c {
+		if isspace(data[2]) {
+			return 0, nil
+		}
+		ret, node := helperDoubleEmphasis(p, data[2:], c)
+		if ret == 0 {
+			return 0, nil
+		}
+
+		return ret + 2, node
+	}
+
+	if len(data) > 4 && data[1] == c && data[2] == c && data[3] != c {
+		if c == '~' || isspace(data[3]) {
+			return 0, nil
+		}
+		ret, node := helperTripleEmphasis(p, data, 3, c)
+		if ret == 0 {
+			return 0, nil
+		}
+
+		return ret + 3, node
+	}
+
+	return 0, nil
+}
+
+func codeSpan(p *Markdown, data []byte, offset int) (int, *Node) {
+	data = data[offset:]
+
+	nb := 0
+
+	// count the number of backticks in the delimiter
+	for nb < len(data) && data[nb] == '`' {
+		nb++
+	}
+
+	// find the next delimiter
+	i, end := 0, 0
+	for end = nb; end < len(data) && i < nb; end++ {
+		if data[end] == '`' {
+			i++
+		} else {
+			i = 0
+		}
+	}
+
+	// no matching delimiter?
+	if i < nb && end >= len(data) {
+		return 0, nil
+	}
+
+	// trim outside whitespace
+	fBegin := nb
+	for fBegin < end && data[fBegin] == ' ' {
+		fBegin++
+	}
+
+	fEnd := end - nb
+	for fEnd > fBegin && data[fEnd-1] == ' ' {
+		fEnd--
+	}
+
+	// render the code span
+	if fBegin != fEnd {
+		code := NewNode(Code)
+		code.Literal = data[fBegin:fEnd]
+		return end, code
+	}
+
+	return end, nil
+}
+
+// newline preceded by two spaces becomes <br>
+func maybeLineBreak(p *Markdown, data []byte, offset int) (int, *Node) {
+	origOffset := offset
+	for offset < len(data) && data[offset] == ' ' {
+		offset++
+	}
+
+	if offset < len(data) && data[offset] == '\n' {
+		if offset-origOffset >= 2 {
+			return offset - origOffset + 1, NewNode(Hardbreak)
+		}
+		return offset - origOffset, nil
+	}
+	return 0, nil
+}
+
+// newline without two spaces works when HardLineBreak is enabled
+func lineBreak(p *Markdown, data []byte, offset int) (int, *Node) {
+	if p.extensions&HardLineBreak != 0 {
+		return 1, NewNode(Hardbreak)
+	}
+	return 0, nil
+}
+
+type linkType int
+
+const (
+	linkNormal linkType = iota
+	linkImg
+	linkDeferredFootnote
+	linkInlineFootnote
+)
+
+func isReferenceStyleLink(data []byte, pos int, t linkType) bool {
+	if t == linkDeferredFootnote {
+		return false
+	}
+	return pos < len(data)-1 && data[pos] == '[' && data[pos+1] != '^'
+}
+
+func maybeImage(p *Markdown, data []byte, offset int) (int, *Node) {
+	if offset < len(data)-1 && data[offset+1] == '[' {
+		return link(p, data, offset)
+	}
+	return 0, nil
+}
+
+func maybeInlineFootnote(p *Markdown, data []byte, offset int) (int, *Node) {
+	if offset < len(data)-1 && data[offset+1] == '[' {
+		return link(p, data, offset)
+	}
+	return 0, nil
+}
+
+// '[': parse a link or an image or a footnote
+func link(p *Markdown, data []byte, offset int) (int, *Node) {
+	// no links allowed inside regular links, footnote, and deferred footnotes
+	if p.insideLink && (offset > 0 && data[offset-1] == '[' || len(data)-1 > offset && data[offset+1] == '^') {
+		return 0, nil
+	}
+
+	var t linkType
+	switch {
+	// special case: ![^text] == deferred footnote (that follows something with
+	// an exclamation point)
+	case p.extensions&Footnotes != 0 && len(data)-1 > offset && data[offset+1] == '^':
+		t = linkDeferredFootnote
+	// ![alt] == image
+	case offset >= 0 && data[offset] == '!':
+		t = linkImg
+		offset++
+	// ^[text] == inline footnote
+	// [^refId] == deferred footnote
+	case p.extensions&Footnotes != 0:
+		if offset >= 0 && data[offset] == '^' {
+			t = linkInlineFootnote
+			offset++
+		} else if len(data)-1 > offset && data[offset+1] == '^' {
+			t = linkDeferredFootnote
+		}
+	// [text] == regular link
+	default:
+		t = linkNormal
+	}
+
+	data = data[offset:]
+
+	var (
+		i                       = 1
+		noteID                  int
+		title, link, altContent []byte
+		textHasNl               = false
+	)
+
+	if t == linkDeferredFootnote {
+		i++
+	}
+
+	// look for the matching closing bracket
+	for level := 1; level > 0 && i < len(data); i++ {
+		switch {
+		case data[i] == '\n':
+			textHasNl = true
+
+		case data[i-1] == '\\':
+			continue
+
+		case data[i] == '[':
+			level++
+
+		case data[i] == ']':
+			level--
+			if level <= 0 {
+				i-- // compensate for extra i++ in for loop
+			}
+		}
+	}
+
+	if i >= len(data) {
+		return 0, nil
+	}
+
+	txtE := i
+	i++
+	var footnoteNode *Node
+
+	// skip any amount of whitespace or newline
+	// (this is much more lax than original markdown syntax)
+	for i < len(data) && isspace(data[i]) {
+		i++
+	}
+
+	// inline style link
+	switch {
+	case i < len(data) && data[i] == '(':
+		// skip initial whitespace
+		i++
+
+		for i < len(data) && isspace(data[i]) {
+			i++
+		}
+
+		linkB := i
+
+		// look for link end: ' " )
+	findlinkend:
+		for i < len(data) {
+			switch {
+			case data[i] == '\\':
+				i += 2
+
+			case data[i] == ')' || data[i] == '\'' || data[i] == '"':
+				break findlinkend
+
+			default:
+				i++
+			}
+		}
+
+		if i >= len(data) {
+			return 0, nil
+		}
+		linkE := i
+
+		// look for title end if present
+		titleB, titleE := 0, 0
+		if data[i] == '\'' || data[i] == '"' {
+			i++
+			titleB = i
+
+		findtitleend:
+			for i < len(data) {
+				switch {
+				case data[i] == '\\':
+					i += 2
+
+				case data[i] == ')':
+					break findtitleend
+
+				default:
+					i++
+				}
+			}
+
+			if i >= len(data) {
+				return 0, nil
+			}
+
+			// skip whitespace after title
+			titleE = i - 1
+			for titleE > titleB && isspace(data[titleE]) {
+				titleE--
+			}
+
+			// check for closing quote presence
+			if data[titleE] != '\'' && data[titleE] != '"' {
+				titleB, titleE = 0, 0
+				linkE = i
+			}
+		}
+
+		// remove whitespace at the end of the link
+		for linkE > linkB && isspace(data[linkE-1]) {
+			linkE--
+		}
+
+		// remove optional angle brackets around the link
+		if data[linkB] == '<' {
+			linkB++
+		}
+		if data[linkE-1] == '>' {
+			linkE--
+		}
+
+		// build escaped link and title
+		if linkE > linkB {
+			link = data[linkB:linkE]
+		}
+
+		if titleE > titleB {
+			title = data[titleB:titleE]
+		}
+
+		i++
+
+	// reference style link
+	case isReferenceStyleLink(data, i, t):
+		var id []byte
+		altContentConsidered := false
+
+		// look for the id
+		i++
+		linkB := i
+		for i < len(data) && data[i] != ']' {
+			i++
+		}
+		if i >= len(data) {
+			return 0, nil
+		}
+		linkE := i
+
+		// find the reference
+		if linkB == linkE {
+			if textHasNl {
+				var b bytes.Buffer
+
+				for j := 1; j < txtE; j++ {
+					switch {
+					case data[j] != '\n':
+						b.WriteByte(data[j])
+					case data[j-1] != ' ':
+						b.WriteByte(' ')
+					}
+				}
+
+				id = b.Bytes()
+			} else {
+				id = data[1:txtE]
+				altContentConsidered = true
+			}
+		} else {
+			id = data[linkB:linkE]
+		}
+
+		// find the reference with matching id
+		lr, ok := p.getRef(string(id))
+		if !ok {
+			return 0, nil
+		}
+
+		// keep link and title from reference
+		link = lr.link
+		title = lr.title
+		if altContentConsidered {
+			altContent = lr.text
+		}
+		i++
+
+	// shortcut reference style link or reference or inline footnote
+	default:
+		var id []byte
+
+		// craft the id
+		if textHasNl {
+			var b bytes.Buffer
+
+			for j := 1; j < txtE; j++ {
+				switch {
+				case data[j] != '\n':
+					b.WriteByte(data[j])
+				case data[j-1] != ' ':
+					b.WriteByte(' ')
+				}
+			}
+
+			id = b.Bytes()
+		} else {
+			if t == linkDeferredFootnote {
+				id = data[2:txtE] // get rid of the ^
+			} else {
+				id = data[1:txtE]
+			}
+		}
+
+		footnoteNode = NewNode(Item)
+		if t == linkInlineFootnote {
+			// create a new reference
+			noteID = len(p.notes) + 1
+
+			var fragment []byte
+			if len(id) > 0 {
+				if len(id) < 16 {
+					fragment = make([]byte, len(id))
+				} else {
+					fragment = make([]byte, 16)
+				}
+				copy(fragment, slugify(id))
+			} else {
+				fragment = append([]byte("footnote-"), []byte(strconv.Itoa(noteID))...)
+			}
+
+			ref := &reference{
+				noteID:   noteID,
+				hasBlock: false,
+				link:     fragment,
+				title:    id,
+				footnote: footnoteNode,
+			}
+
+			p.notes = append(p.notes, ref)
+
+			link = ref.link
+			title = ref.title
+		} else {
+			// find the reference with matching id
+			lr, ok := p.getRef(string(id))
+			if !ok {
+				return 0, nil
+			}
+
+			if t == linkDeferredFootnote {
+				lr.noteID = len(p.notes) + 1
+				lr.footnote = footnoteNode
+				p.notes = append(p.notes, lr)
+			}
+
+			// keep link and title from reference
+			link = lr.link
+			// if inline footnote, title == footnote contents
+			title = lr.title
+			noteID = lr.noteID
+		}
+
+		// rewind the whitespace
+		i = txtE + 1
+	}
+
+	var uLink []byte
+	if t == linkNormal || t == linkImg {
+		if len(link) > 0 {
+			var uLinkBuf bytes.Buffer
+			unescapeText(&uLinkBuf, link)
+			uLink = uLinkBuf.Bytes()
+		}
+
+		// links need something to click on and somewhere to go
+		if len(uLink) == 0 || (t == linkNormal && txtE <= 1) {
+			return 0, nil
+		}
+	}
+
+	// call the relevant rendering function
+	var linkNode *Node
+	switch t {
+	case linkNormal:
+		linkNode = NewNode(Link)
+		linkNode.Destination = normalizeURI(uLink)
+		linkNode.Title = title
+		if len(altContent) > 0 {
+			linkNode.AppendChild(text(altContent))
+		} else {
+			// links cannot contain other links, so turn off link parsing
+			// temporarily and recurse
+			insideLink := p.insideLink
+			p.insideLink = true
+			p.inline(linkNode, data[1:txtE])
+			p.insideLink = insideLink
+		}
+
+	case linkImg:
+		linkNode = NewNode(Image)
+		linkNode.Destination = uLink
+		linkNode.Title = title
+		linkNode.AppendChild(text(data[1:txtE]))
+		i++
+
+	case linkInlineFootnote, linkDeferredFootnote:
+		linkNode = NewNode(Link)
+		linkNode.Destination = link
+		linkNode.Title = title
+		linkNode.NoteID = noteID
+		linkNode.Footnote = footnoteNode
+		if t == linkInlineFootnote {
+			i++
+		}
+
+	default:
+		return 0, nil
+	}
+
+	return i, linkNode
+}
+
+func (p *Markdown) inlineHTMLComment(data []byte) int {
+	if len(data) < 5 {
+		return 0
+	}
+	if data[0] != '<' || data[1] != '!' || data[2] != '-' || data[3] != '-' {
+		return 0
+	}
+	i := 5
+	// scan for an end-of-comment marker, across lines if necessary
+	for i < len(data) && !(data[i-2] == '-' && data[i-1] == '-' && data[i] == '>') {
+		i++
+	}
+	// no end-of-comment marker
+	if i >= len(data) {
+		return 0
+	}
+	return i + 1
+}
+
+func stripMailto(link []byte) []byte {
+	if bytes.HasPrefix(link, []byte("mailto://")) {
+		return link[9:]
+	} else if bytes.HasPrefix(link, []byte("mailto:")) {
+		return link[7:]
+	} else {
+		return link
+	}
+}
+
+// autolinkType specifies a kind of autolink that gets detected.
+type autolinkType int
+
+// These are the possible flag values for the autolink renderer.
+const (
+	notAutolink autolinkType = iota
+	normalAutolink
+	emailAutolink
+)
+
+// '<' when tags or autolinks are allowed
+func leftAngle(p *Markdown, data []byte, offset int) (int, *Node) {
+	data = data[offset:]
+	altype, end := tagLength(data)
+	if size := p.inlineHTMLComment(data); size > 0 {
+		end = size
+	}
+	if end > 2 {
+		if altype != notAutolink {
+			var uLink bytes.Buffer
+			unescapeText(&uLink, data[1:end+1-2])
+			if uLink.Len() > 0 {
+				link := uLink.Bytes()
+				node := NewNode(Link)
+				node.Destination = link
+				if altype == emailAutolink {
+					node.Destination = append([]byte("mailto:"), link...)
+				}
+				node.AppendChild(text(stripMailto(link)))
+				return end, node
+			}
+		} else {
+			htmlTag := NewNode(HTMLSpan)
+			htmlTag.Literal = data[:end]
+			return end, htmlTag
+		}
+	}
+
+	return end, nil
+}
+
+// '\\' backslash escape
+var escapeChars = []byte("\\`*_{}[]()#+-.!:|&<>~")
+
+func escape(p *Markdown, data []byte, offset int) (int, *Node) {
+	data = data[offset:]
+
+	if len(data) > 1 {
+		if p.extensions&BackslashLineBreak != 0 && data[1] == '\n' {
+			return 2, NewNode(Hardbreak)
+		}
+		if bytes.IndexByte(escapeChars, data[1]) < 0 {
+			return 0, nil
+		}
+
+		return 2, text(data[1:2])
+	}
+
+	return 2, nil
+}
+
+func unescapeText(ob *bytes.Buffer, src []byte) {
+	i := 0
+	for i < len(src) {
+		org := i
+		for i < len(src) && src[i] != '\\' {
+			i++
+		}
+
+		if i > org {
+			ob.Write(src[org:i])
+		}
+
+		if i+1 >= len(src) {
+			break
+		}
+
+		ob.WriteByte(src[i+1])
+		i += 2
+	}
+}
+
+// '&' escaped when it doesn't belong to an entity
+// valid entities are assumed to be anything matching &#?[A-Za-z0-9]+;
+func entity(p *Markdown, data []byte, offset int) (int, *Node) {
+	data = data[offset:]
+
+	end := 1
+
+	if end < len(data) && data[end] == '#' {
+		end++
+	}
+
+	for end < len(data) && isalnum(data[end]) {
+		end++
+	}
+
+	if end < len(data) && data[end] == ';' {
+		end++ // real entity
+	} else {
+		return 0, nil // lone '&'
+	}
+
+	ent := data[:end]
+	// undo &amp; escaping or it will be converted to &amp;amp; by another
+	// escaper in the renderer
+	if bytes.Equal(ent, []byte("&amp;")) {
+		ent = []byte{'&'}
+	}
+
+	return end, text(ent)
+}
+
+func linkEndsWithEntity(data []byte, linkEnd int) bool {
+	entityRanges := htmlEntityRe.FindAllIndex(data[:linkEnd], -1)
+	return entityRanges != nil && entityRanges[len(entityRanges)-1][1] == linkEnd
+}
+
+// hasPrefixCaseInsensitive is a custom implementation of
+//     strings.HasPrefix(strings.ToLower(s), prefix)
+// we rolled our own because ToLower pulls in a huge machinery of lowercasing
+// anything from Unicode and that's very slow. Since this func will only be
+// used on ASCII protocol prefixes, we can take shortcuts.
+func hasPrefixCaseInsensitive(s, prefix []byte) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	delta := byte('a' - 'A')
+	for i, b := range prefix {
+		if b != s[i] && b != s[i]+delta {
+			return false
+		}
+	}
+	return true
+}
+
+var protocolPrefixes = [][]byte{
+	[]byte("http://"),
+	[]byte("https://"),
+	[]byte("ftp://"),
+	[]byte("file://"),
+	[]byte("mailto:"),
+}
+
+const shortestPrefix = 6 // len("ftp://"), the shortest of the above
+
+func maybeAutoLink(p *Markdown, data []byte, offset int) (int, *Node) {
+	// quick check to rule out most false hits
+	if p.insideLink || len(data) < offset+shortestPrefix {
+		return 0, nil
+	}
+	for _, prefix := range protocolPrefixes {
+		endOfHead := offset + 8 // 8 is the len() of the longest prefix
+		if endOfHead > len(data) {
+			endOfHead = len(data)
+		}
+		if hasPrefixCaseInsensitive(data[offset:endOfHead], prefix) {
+			return autoLink(p, data, offset)
+		}
+	}
+	return 0, nil
+}
+
+func autoLink(p *Markdown, data []byte, offset int) (int, *Node) {
+	// Now a more expensive check to see if we're not inside an anchor element
+	anchorStart := offset
+	offsetFromAnchor := 0
+	for anchorStart > 0 && data[anchorStart] != '<' {
+		anchorStart--
+		offsetFromAnchor++
+	}
+
+	anchorStr := anchorRe.Find(data[anchorStart:])
+	if anchorStr != nil {
+		anchorClose := NewNode(HTMLSpan)
+		anchorClose.Literal = anchorStr[offsetFromAnchor:]
+		return len(anchorStr) - offsetFromAnchor, anchorClose
+	}
+
+	// scan backward for a word boundary
+	rewind := 0
+	for offset-rewind > 0 && rewind <= 7 && isletter(data[offset-rewind-1]) {
+		rewind++
+	}
+	if rewind > 6 { // longest supported protocol is "mailto" which has 6 letters
+		return 0, nil
+	}
+
+	origData := data
+	data = data[offset-rewind:]
+
+	if !isSafeLink(data) {
+		return 0, nil
+	}
+
+	linkEnd := 0
+	for linkEnd < len(data) && !isEndOfLink(data[linkEnd]) {
+		linkEnd++
+	}
+
+	// Skip punctuation at the end of the link
+	if (data[linkEnd-1] == '.' || data[linkEnd-1] == ',') && data[linkEnd-2] != '\\' {
+		linkEnd--
+	}
+
+	// But don't skip semicolon if it's a part of escaped entity:
+	if data[linkEnd-1] == ';' && data[linkEnd-2] != '\\' && !linkEndsWithEntity(data, linkEnd) {
+		linkEnd--
+	}
+
+	// See if the link finishes with a punctuation sign that can be closed.
+	var copen byte
+	switch data[linkEnd-1] {
+	case '"':
+		copen = '"'
+	case '\'':
+		copen = '\''
+	case ')':
+		copen = '('
+	case ']':
+		copen = '['
+	case '}':
+		copen = '{'
+	default:
+		copen = 0
+	}
+
+	if copen != 0 {
+		bufEnd := offset - rewind + linkEnd - 2
+
+		openDelim := 1
+
+		/* Try to close the final punctuation sign in this same line;
+		 * if we managed to close it outside of the URL, that means that it's
+		 * not part of the URL. If it closes inside the URL, that means it
+		 * is part of the URL.
+		 *
+		 * Examples:
+		 *
+		 *      foo http://www.pokemon.com/Pikachu_(Electric) bar
+		 *              => http://www.pokemon.com/Pikachu_(Electric)
+		 *
+		 *      foo (http://www.pokemon.com/Pikachu_(Electric)) bar
+		 *              => http://www.pokemon.com/Pikachu_(Electric)
+		 *
+		 *      foo http://www.pokemon.com/Pikachu_(Electric)) bar
+		 *              => http://www.pokemon.com/Pikachu_(Electric))
+		 *
+		 *      (foo http://www.pokemon.com/Pikachu_(Electric)) bar
+		 *              => foo http://www.pokemon.com/Pikachu_(Electric)
+		 */
+
+		for bufEnd >= 0 && origData[bufEnd] != '\n' && openDelim != 0 {
+			if origData[bufEnd] == data[linkEnd-1] {
+				openDelim++
+			}
+
+			if origData[bufEnd] == copen {
+				openDelim--
+			}
+
+			bufEnd--
+		}
+
+		if openDelim == 0 {
+			linkEnd--
+		}
+	}
+
+	var uLink bytes.Buffer
+	unescapeText(&uLink, data[:linkEnd])
+
+	if uLink.Len() > 0 {
+		node := NewNode(Link)
+		node.Destination = uLink.Bytes()
+		node.AppendChild(text(uLink.Bytes()))
+		return linkEnd, node
+	}
+
+	return linkEnd, nil
+}
+
+func isEndOfLink(char byte) bool {
+	return isspace(char) || char == '<'
+}
+
+var validUris = [][]byte{[]byte("http://"), []byte("https://"), []byte("ftp://"), []byte("mailto://")}
+var validPaths = [][]byte{[]byte("/"), []byte("./"), []byte("../")}
+
+func isSafeLink(link []byte) bool {
+	for _, path := range validPaths {
+		if len(link) >= len(path) && bytes.Equal(link[:len(path)], path) {
+			if len(link) == len(path) {
+				return true
+			} else if isalnum(link[len(path)]) {
+				return true
+			}
+		}
+	}
+
+	for _, prefix := range validUris {
+		// TODO: handle unicode here
+		// case-insensitive prefix test
+		if len(link) > len(prefix) && bytes.Equal(bytes.ToLower(link[:len(prefix)]), prefix) && isalnum(link[len(prefix)]) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// return the length of the given tag, or 0 is it's not valid
+func tagLength(data []byte) (autolink autolinkType, end int) {
+	var i, j int
+
+	// a valid tag can't be shorter than 3 chars
+	if len(data) < 3 {
+		return notAutolink, 0
+	}
+
+	// begins with a '<' optionally followed by '/', followed by letter or number
+	if data[0] != '<' {
+		return notAutolink, 0
+	}
+	if data[1] == '/' {
+		i = 2
+	} else {
+		i = 1
+	}
+
+	if !isalnum(data[i]) {
+		return notAutolink, 0
+	}
+
+	// scheme test
+	autolink = notAutolink
+
+	// try to find the beginning of an URI
+	for i < len(data) && (isalnum(data[i]) || data[i] == '.' || data[i] == '+' || data[i] == '-') {
+		i++
+	}
+
+	if i > 1 && i < len(data) && data[i] == '@' {
+		if j = isMailtoAutoLink(data[i:]); j != 0 {
+			return emailAutolink, i + j
+		}
+	}
+
+	if i > 2 && i < len(data) && data[i] == ':' {
+		autolink = normalAutolink
+		i++
+	}
+
+	// complete autolink test: no whitespace or ' or "
+	switch {
+	case i >= len(data):
+		autolink = notAutolink
+	case autolink != notAutolink:
+		j = i
+
+		for i < len(data) {
+			if data[i] == '\\' {
+				i += 2
+			} else if data[i] == '>' || data[i] == '\'' || data[i] == '"' || isspace(data[i]) {
+				break
+			} else {
+				i++
+			}
+
+		}
+
+		if i >= len(data) {
+			return autolink, 0
+		}
+		if i > j && data[i] == '>' {
+			return autolink, i + 1
+		}
+
+		// one of the forbidden chars has been found
+		autolink = notAutolink
+	}
+	i += bytes.IndexByte(data[i:], '>')
+	if i < 0 {
+		return autolink, 0
+	}
+	return autolink, i + 1
+}
+
+// look for the address part of a mail autolink and '>'
+// this is less strict than the original markdown e-mail address matching
+func isMailtoAutoLink(data []byte) int {
+	nb := 0
+
+	// address is assumed to be: [-@._a-zA-Z0-9]+ with exactly one '@'
+	for i := 0; i < len(data); i++ {
+		if isalnum(data[i]) {
+			continue
+		}
+
+		switch data[i] {
+		case '@':
+			nb++
+
+		case '-', '.', '_':
+			break
+
+		case '>':
+			if nb == 1 {
+				return i + 1
+			}
+			return 0
+		default:
+			return 0
+		}
+	}
+
+	return 0
+}
+
+// look for the next emph char, skipping other constructs
+func helperFindEmphChar(data []byte, c byte) int {
+	i := 0
+
+	for i < len(data) {
+		for i < len(data) && data[i] != c && data[i] != '`' && data[i] != '[' {
+			i++
+		}
+		if i >= len(data) {
+			return 0
+		}
+		// do not count escaped chars
+		if i != 0 && data[i-1] == '\\' {
+			i++
+			continue
+		}
+		if data[i] == c {
+			return i
+		}
+
+		if data[i] == '`' {
+			// skip a code span
+			tmpI := 0
+			i++
+			for i < len(data) && data[i] != '`' {
+				if tmpI == 0 && data[i] == c {
+					tmpI = i
+				}
+				i++
+			}
+			if i >= len(data) {
+				return tmpI
+			}
+			i++
+		} else if data[i] == '[' {
+			// skip a link
+			tmpI := 0
+			i++
+			for i < len(data) && data[i] != ']' {
+				if tmpI == 0 && data[i] == c {
+					tmpI = i
+				}
+				i++
+			}
+			i++
+			for i < len(data) && (data[i] == ' ' || data[i] == '\n') {
+				i++
+			}
+			if i >= len(data) {
+				return tmpI
+			}
+			if data[i] != '[' && data[i] != '(' { // not a link
+				if tmpI > 0 {
+					return tmpI
+				}
+				continue
+			}
+			cc := data[i]
+			i++
+			for i < len(data) && data[i] != cc {
+				if tmpI == 0 && data[i] == c {
+					return i
+				}
+				i++
+			}
+			if i >= len(data) {
+				return tmpI
+			}
+			i++
+		}
+	}
+	return 0
+}
+
+func helperEmphasis(p *Markdown, data []byte, c byte) (int, *Node) {
+	i := 0
+
+	// skip one symbol if coming from emph3
+	if len(data) > 1 && data[0] == c && data[1] == c {
+		i = 1
+	}
+
+	for i < len(data) {
+		length := helperFindEmphChar(data[i:], c)
+		if length == 0 {
+			return 0, nil
+		}
+		i += length
+		if i >= len(data) {
+			return 0, nil
+		}
+
+		if i+1 < len(data) && data[i+1] == c {
+			i++
+			continue
+		}
+
+		if data[i] == c && !isspace(data[i-1]) {
+
+			if p.extensions&NoIntraEmphasis != 0 {
+				if !(i+1 == len(data) || isspace(data[i+1]) || ispunct(data[i+1])) {
+					continue
+				}
+			}
+
+			emph := NewNode(Emph)
+			p.inline(emph, data[:i])
+			return i + 1, emph
+		}
+	}
+
+	return 0, nil
+}
+
+func helperDoubleEmphasis(p *Markdown, data []byte, c byte) (int, *Node) {
+	i := 0
+
+	for i < len(data) {
+		length := helperFindEmphChar(data[i:], c)
+		if length == 0 {
+			return 0, nil
+		}
+		i += length
+
+		if i+1 < len(data) && data[i] == c && data[i+1] == c && i > 0 && !isspace(data[i-1]) {
+			nodeType := Strong
+			if c == '~' {
+				nodeType = Del
+			}
+			node := NewNode(nodeType)
+			p.inline(node, data[:i])
+			return i + 2, node
+		}
+		i++
+	}
+	return 0, nil
+}
+
+func helperTripleEmphasis(p *Markdown, data []byte, offset int, c byte) (int, *Node) {
+	i := 0
+	origData := data
+	data = data[offset:]
+
+	for i < len(data) {
+		length := helperFindEmphChar(data[i:], c)
+		if length == 0 {
+			return 0, nil
+		}
+		i += length
+
+		// skip whitespace preceded symbols
+		if data[i] != c || isspace(data[i-1]) {
+			continue
+		}
+
+		switch {
+		case i+2 < len(data) && data[i+1] == c && data[i+2] == c:
+			// triple symbol found
+			strong := NewNode(Strong)
+			em := NewNode(Emph)
+			strong.AppendChild(em)
+			p.inline(em, data[:i])
+			return i + 3, strong
+		case (i+1 < len(data) && data[i+1] == c):
+			// double symbol found, hand over to emph1
+			length, node := helperEmphasis(p, origData[offset-2:], c)
+			if length == 0 {
+				return 0, nil
+			}
+			return length - 2, node
+		default:
+			// single symbol found, hand over to emph2
+			length, node := helperDoubleEmphasis(p, origData[offset-1:], c)
+			if length == 0 {
+				return 0, nil
+			}
+			return length - 1, node
+		}
+	}
+	return 0, nil
+}
+
+func text(s []byte) *Node {
+	node := NewNode(Text)
+	node.Literal = s
+	return node
+}
+
+func normalizeURI(s []byte) []byte {
+	return s // TODO: implement
+}

--- a/vendor/github.com/russross/blackfriday/v2/markdown.go
+++ b/vendor/github.com/russross/blackfriday/v2/markdown.go
@@ -1,0 +1,950 @@
+// Blackfriday Markdown Processor
+// Available at http://github.com/russross/blackfriday
+//
+// Copyright © 2011 Russ Ross <russ@russross.com>.
+// Distributed under the Simplified BSD License.
+// See README.md for details.
+
+package blackfriday
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+//
+// Markdown parsing and processing
+//
+
+// Version string of the package. Appears in the rendered document when
+// CompletePage flag is on.
+const Version = "2.0"
+
+// Extensions is a bitwise or'ed collection of enabled Blackfriday's
+// extensions.
+type Extensions int
+
+// These are the supported markdown parsing extensions.
+// OR these values together to select multiple extensions.
+const (
+	NoExtensions           Extensions = 0
+	NoIntraEmphasis        Extensions = 1 << iota // Ignore emphasis markers inside words
+	Tables                                        // Render tables
+	FencedCode                                    // Render fenced code blocks
+	Autolink                                      // Detect embedded URLs that are not explicitly marked
+	Strikethrough                                 // Strikethrough text using ~~test~~
+	LaxHTMLBlocks                                 // Loosen up HTML block parsing rules
+	SpaceHeadings                                 // Be strict about prefix heading rules
+	HardLineBreak                                 // Translate newlines into line breaks
+	TabSizeEight                                  // Expand tabs to eight spaces instead of four
+	Footnotes                                     // Pandoc-style footnotes
+	NoEmptyLineBeforeBlock                        // No need to insert an empty line to start a (code, quote, ordered list, unordered list) block
+	HeadingIDs                                    // specify heading IDs  with {#id}
+	Titleblock                                    // Titleblock ala pandoc
+	AutoHeadingIDs                                // Create the heading ID from the text
+	BackslashLineBreak                            // Translate trailing backslashes into line breaks
+	DefinitionLists                               // Render definition lists
+
+	CommonHTMLFlags HTMLFlags = UseXHTML | Smartypants |
+		SmartypantsFractions | SmartypantsDashes | SmartypantsLatexDashes
+
+	CommonExtensions Extensions = NoIntraEmphasis | Tables | FencedCode |
+		Autolink | Strikethrough | SpaceHeadings | HeadingIDs |
+		BackslashLineBreak | DefinitionLists
+)
+
+// ListType contains bitwise or'ed flags for list and list item objects.
+type ListType int
+
+// These are the possible flag values for the ListItem renderer.
+// Multiple flag values may be ORed together.
+// These are mostly of interest if you are writing a new output format.
+const (
+	ListTypeOrdered ListType = 1 << iota
+	ListTypeDefinition
+	ListTypeTerm
+
+	ListItemContainsBlock
+	ListItemBeginningOfList // TODO: figure out if this is of any use now
+	ListItemEndOfList
+)
+
+// CellAlignFlags holds a type of alignment in a table cell.
+type CellAlignFlags int
+
+// These are the possible flag values for the table cell renderer.
+// Only a single one of these values will be used; they are not ORed together.
+// These are mostly of interest if you are writing a new output format.
+const (
+	TableAlignmentLeft CellAlignFlags = 1 << iota
+	TableAlignmentRight
+	TableAlignmentCenter = (TableAlignmentLeft | TableAlignmentRight)
+)
+
+// The size of a tab stop.
+const (
+	TabSizeDefault = 4
+	TabSizeDouble  = 8
+)
+
+// blockTags is a set of tags that are recognized as HTML block tags.
+// Any of these can be included in markdown text without special escaping.
+var blockTags = map[string]struct{}{
+	"blockquote": {},
+	"del":        {},
+	"div":        {},
+	"dl":         {},
+	"fieldset":   {},
+	"form":       {},
+	"h1":         {},
+	"h2":         {},
+	"h3":         {},
+	"h4":         {},
+	"h5":         {},
+	"h6":         {},
+	"iframe":     {},
+	"ins":        {},
+	"math":       {},
+	"noscript":   {},
+	"ol":         {},
+	"pre":        {},
+	"p":          {},
+	"script":     {},
+	"style":      {},
+	"table":      {},
+	"ul":         {},
+
+	// HTML5
+	"address":    {},
+	"article":    {},
+	"aside":      {},
+	"canvas":     {},
+	"figcaption": {},
+	"figure":     {},
+	"footer":     {},
+	"header":     {},
+	"hgroup":     {},
+	"main":       {},
+	"nav":        {},
+	"output":     {},
+	"progress":   {},
+	"section":    {},
+	"video":      {},
+}
+
+// Renderer is the rendering interface. This is mostly of interest if you are
+// implementing a new rendering format.
+//
+// Only an HTML implementation is provided in this repository, see the README
+// for external implementations.
+type Renderer interface {
+	// RenderNode is the main rendering method. It will be called once for
+	// every leaf node and twice for every non-leaf node (first with
+	// entering=true, then with entering=false). The method should write its
+	// rendition of the node to the supplied writer w.
+	RenderNode(w io.Writer, node *Node, entering bool) WalkStatus
+
+	// RenderHeader is a method that allows the renderer to produce some
+	// content preceding the main body of the output document. The header is
+	// understood in the broad sense here. For example, the default HTML
+	// renderer will write not only the HTML document preamble, but also the
+	// table of contents if it was requested.
+	//
+	// The method will be passed an entire document tree, in case a particular
+	// implementation needs to inspect it to produce output.
+	//
+	// The output should be written to the supplied writer w. If your
+	// implementation has no header to write, supply an empty implementation.
+	RenderHeader(w io.Writer, ast *Node)
+
+	// RenderFooter is a symmetric counterpart of RenderHeader.
+	RenderFooter(w io.Writer, ast *Node)
+}
+
+// Callback functions for inline parsing. One such function is defined
+// for each character that triggers a response when parsing inline data.
+type inlineParser func(p *Markdown, data []byte, offset int) (int, *Node)
+
+// Markdown is a type that holds extensions and the runtime state used by
+// Parse, and the renderer. You can not use it directly, construct it with New.
+type Markdown struct {
+	renderer          Renderer
+	referenceOverride ReferenceOverrideFunc
+	refs              map[string]*reference
+	inlineCallback    [256]inlineParser
+	extensions        Extensions
+	nesting           int
+	maxNesting        int
+	insideLink        bool
+
+	// Footnotes need to be ordered as well as available to quickly check for
+	// presence. If a ref is also a footnote, it's stored both in refs and here
+	// in notes. Slice is nil if footnotes not enabled.
+	notes []*reference
+
+	doc                  *Node
+	tip                  *Node // = doc
+	oldTip               *Node
+	lastMatchedContainer *Node // = doc
+	allClosed            bool
+}
+
+func (p *Markdown) getRef(refid string) (ref *reference, found bool) {
+	if p.referenceOverride != nil {
+		r, overridden := p.referenceOverride(refid)
+		if overridden {
+			if r == nil {
+				return nil, false
+			}
+			return &reference{
+				link:     []byte(r.Link),
+				title:    []byte(r.Title),
+				noteID:   0,
+				hasBlock: false,
+				text:     []byte(r.Text)}, true
+		}
+	}
+	// refs are case insensitive
+	ref, found = p.refs[strings.ToLower(refid)]
+	return ref, found
+}
+
+func (p *Markdown) finalize(block *Node) {
+	above := block.Parent
+	block.open = false
+	p.tip = above
+}
+
+func (p *Markdown) addChild(node NodeType, offset uint32) *Node {
+	return p.addExistingChild(NewNode(node), offset)
+}
+
+func (p *Markdown) addExistingChild(node *Node, offset uint32) *Node {
+	for !p.tip.canContain(node.Type) {
+		p.finalize(p.tip)
+	}
+	p.tip.AppendChild(node)
+	p.tip = node
+	return node
+}
+
+func (p *Markdown) closeUnmatchedBlocks() {
+	if !p.allClosed {
+		for p.oldTip != p.lastMatchedContainer {
+			parent := p.oldTip.Parent
+			p.finalize(p.oldTip)
+			p.oldTip = parent
+		}
+		p.allClosed = true
+	}
+}
+
+//
+//
+// Public interface
+//
+//
+
+// Reference represents the details of a link.
+// See the documentation in Options for more details on use-case.
+type Reference struct {
+	// Link is usually the URL the reference points to.
+	Link string
+	// Title is the alternate text describing the link in more detail.
+	Title string
+	// Text is the optional text to override the ref with if the syntax used was
+	// [refid][]
+	Text string
+}
+
+// ReferenceOverrideFunc is expected to be called with a reference string and
+// return either a valid Reference type that the reference string maps to or
+// nil. If overridden is false, the default reference logic will be executed.
+// See the documentation in Options for more details on use-case.
+type ReferenceOverrideFunc func(reference string) (ref *Reference, overridden bool)
+
+// New constructs a Markdown processor. You can use the same With* functions as
+// for Run() to customize parser's behavior and the renderer.
+func New(opts ...Option) *Markdown {
+	var p Markdown
+	for _, opt := range opts {
+		opt(&p)
+	}
+	p.refs = make(map[string]*reference)
+	p.maxNesting = 16
+	p.insideLink = false
+	docNode := NewNode(Document)
+	p.doc = docNode
+	p.tip = docNode
+	p.oldTip = docNode
+	p.lastMatchedContainer = docNode
+	p.allClosed = true
+	// register inline parsers
+	p.inlineCallback[' '] = maybeLineBreak
+	p.inlineCallback['*'] = emphasis
+	p.inlineCallback['_'] = emphasis
+	if p.extensions&Strikethrough != 0 {
+		p.inlineCallback['~'] = emphasis
+	}
+	p.inlineCallback['`'] = codeSpan
+	p.inlineCallback['\n'] = lineBreak
+	p.inlineCallback['['] = link
+	p.inlineCallback['<'] = leftAngle
+	p.inlineCallback['\\'] = escape
+	p.inlineCallback['&'] = entity
+	p.inlineCallback['!'] = maybeImage
+	p.inlineCallback['^'] = maybeInlineFootnote
+	if p.extensions&Autolink != 0 {
+		p.inlineCallback['h'] = maybeAutoLink
+		p.inlineCallback['m'] = maybeAutoLink
+		p.inlineCallback['f'] = maybeAutoLink
+		p.inlineCallback['H'] = maybeAutoLink
+		p.inlineCallback['M'] = maybeAutoLink
+		p.inlineCallback['F'] = maybeAutoLink
+	}
+	if p.extensions&Footnotes != 0 {
+		p.notes = make([]*reference, 0)
+	}
+	return &p
+}
+
+// Option customizes the Markdown processor's default behavior.
+type Option func(*Markdown)
+
+// WithRenderer allows you to override the default renderer.
+func WithRenderer(r Renderer) Option {
+	return func(p *Markdown) {
+		p.renderer = r
+	}
+}
+
+// WithExtensions allows you to pick some of the many extensions provided by
+// Blackfriday. You can bitwise OR them.
+func WithExtensions(e Extensions) Option {
+	return func(p *Markdown) {
+		p.extensions = e
+	}
+}
+
+// WithNoExtensions turns off all extensions and custom behavior.
+func WithNoExtensions() Option {
+	return func(p *Markdown) {
+		p.extensions = NoExtensions
+		p.renderer = NewHTMLRenderer(HTMLRendererParameters{
+			Flags: HTMLFlagsNone,
+		})
+	}
+}
+
+// WithRefOverride sets an optional function callback that is called every
+// time a reference is resolved.
+//
+// In Markdown, the link reference syntax can be made to resolve a link to
+// a reference instead of an inline URL, in one of the following ways:
+//
+//  * [link text][refid]
+//  * [refid][]
+//
+// Usually, the refid is defined at the bottom of the Markdown document. If
+// this override function is provided, the refid is passed to the override
+// function first, before consulting the defined refids at the bottom. If
+// the override function indicates an override did not occur, the refids at
+// the bottom will be used to fill in the link details.
+func WithRefOverride(o ReferenceOverrideFunc) Option {
+	return func(p *Markdown) {
+		p.referenceOverride = o
+	}
+}
+
+// Run is the main entry point to Blackfriday. It parses and renders a
+// block of markdown-encoded text.
+//
+// The simplest invocation of Run takes one argument, input:
+//     output := Run(input)
+// This will parse the input with CommonExtensions enabled and render it with
+// the default HTMLRenderer (with CommonHTMLFlags).
+//
+// Variadic arguments opts can customize the default behavior. Since Markdown
+// type does not contain exported fields, you can not use it directly. Instead,
+// use the With* functions. For example, this will call the most basic
+// functionality, with no extensions:
+//     output := Run(input, WithNoExtensions())
+//
+// You can use any number of With* arguments, even contradicting ones. They
+// will be applied in order of appearance and the latter will override the
+// former:
+//     output := Run(input, WithNoExtensions(), WithExtensions(exts),
+//         WithRenderer(yourRenderer))
+func Run(input []byte, opts ...Option) []byte {
+	r := NewHTMLRenderer(HTMLRendererParameters{
+		Flags: CommonHTMLFlags,
+	})
+	optList := []Option{WithRenderer(r), WithExtensions(CommonExtensions)}
+	optList = append(optList, opts...)
+	parser := New(optList...)
+	ast := parser.Parse(input)
+	var buf bytes.Buffer
+	parser.renderer.RenderHeader(&buf, ast)
+	ast.Walk(func(node *Node, entering bool) WalkStatus {
+		return parser.renderer.RenderNode(&buf, node, entering)
+	})
+	parser.renderer.RenderFooter(&buf, ast)
+	return buf.Bytes()
+}
+
+// Parse is an entry point to the parsing part of Blackfriday. It takes an
+// input markdown document and produces a syntax tree for its contents. This
+// tree can then be rendered with a default or custom renderer, or
+// analyzed/transformed by the caller to whatever non-standard needs they have.
+// The return value is the root node of the syntax tree.
+func (p *Markdown) Parse(input []byte) *Node {
+	p.block(input)
+	// Walk the tree and finish up some of unfinished blocks
+	for p.tip != nil {
+		p.finalize(p.tip)
+	}
+	// Walk the tree again and process inline markdown in each block
+	p.doc.Walk(func(node *Node, entering bool) WalkStatus {
+		if node.Type == Paragraph || node.Type == Heading || node.Type == TableCell {
+			p.inline(node, node.content)
+			node.content = nil
+		}
+		return GoToNext
+	})
+	p.parseRefsToAST()
+	return p.doc
+}
+
+func (p *Markdown) parseRefsToAST() {
+	if p.extensions&Footnotes == 0 || len(p.notes) == 0 {
+		return
+	}
+	p.tip = p.doc
+	block := p.addBlock(List, nil)
+	block.IsFootnotesList = true
+	block.ListFlags = ListTypeOrdered
+	flags := ListItemBeginningOfList
+	// Note: this loop is intentionally explicit, not range-form. This is
+	// because the body of the loop will append nested footnotes to p.notes and
+	// we need to process those late additions. Range form would only walk over
+	// the fixed initial set.
+	for i := 0; i < len(p.notes); i++ {
+		ref := p.notes[i]
+		p.addExistingChild(ref.footnote, 0)
+		block := ref.footnote
+		block.ListFlags = flags | ListTypeOrdered
+		block.RefLink = ref.link
+		if ref.hasBlock {
+			flags |= ListItemContainsBlock
+			p.block(ref.title)
+		} else {
+			p.inline(block, ref.title)
+		}
+		flags &^= ListItemBeginningOfList | ListItemContainsBlock
+	}
+	above := block.Parent
+	finalizeList(block)
+	p.tip = above
+	block.Walk(func(node *Node, entering bool) WalkStatus {
+		if node.Type == Paragraph || node.Type == Heading {
+			p.inline(node, node.content)
+			node.content = nil
+		}
+		return GoToNext
+	})
+}
+
+//
+// Link references
+//
+// This section implements support for references that (usually) appear
+// as footnotes in a document, and can be referenced anywhere in the document.
+// The basic format is:
+//
+//    [1]: http://www.google.com/ "Google"
+//    [2]: http://www.github.com/ "Github"
+//
+// Anywhere in the document, the reference can be linked by referring to its
+// label, i.e., 1 and 2 in this example, as in:
+//
+//    This library is hosted on [Github][2], a git hosting site.
+//
+// Actual footnotes as specified in Pandoc and supported by some other Markdown
+// libraries such as php-markdown are also taken care of. They look like this:
+//
+//    This sentence needs a bit of further explanation.[^note]
+//
+//    [^note]: This is the explanation.
+//
+// Footnotes should be placed at the end of the document in an ordered list.
+// Finally, there are inline footnotes such as:
+//
+//    Inline footnotes^[Also supported.] provide a quick inline explanation,
+//    but are rendered at the bottom of the document.
+//
+
+// reference holds all information necessary for a reference-style links or
+// footnotes.
+//
+// Consider this markdown with reference-style links:
+//
+//     [link][ref]
+//
+//     [ref]: /url/ "tooltip title"
+//
+// It will be ultimately converted to this HTML:
+//
+//     <p><a href=\"/url/\" title=\"title\">link</a></p>
+//
+// And a reference structure will be populated as follows:
+//
+//     p.refs["ref"] = &reference{
+//         link: "/url/",
+//         title: "tooltip title",
+//     }
+//
+// Alternatively, reference can contain information about a footnote. Consider
+// this markdown:
+//
+//     Text needing a footnote.[^a]
+//
+//     [^a]: This is the note
+//
+// A reference structure will be populated as follows:
+//
+//     p.refs["a"] = &reference{
+//         link: "a",
+//         title: "This is the note",
+//         noteID: <some positive int>,
+//     }
+//
+// TODO: As you can see, it begs for splitting into two dedicated structures
+// for refs and for footnotes.
+type reference struct {
+	link     []byte
+	title    []byte
+	noteID   int // 0 if not a footnote ref
+	hasBlock bool
+	footnote *Node // a link to the Item node within a list of footnotes
+
+	text []byte // only gets populated by refOverride feature with Reference.Text
+}
+
+func (r *reference) String() string {
+	return fmt.Sprintf("{link: %q, title: %q, text: %q, noteID: %d, hasBlock: %v}",
+		r.link, r.title, r.text, r.noteID, r.hasBlock)
+}
+
+// Check whether or not data starts with a reference link.
+// If so, it is parsed and stored in the list of references
+// (in the render struct).
+// Returns the number of bytes to skip to move past it,
+// or zero if the first line is not a reference.
+func isReference(p *Markdown, data []byte, tabSize int) int {
+	// up to 3 optional leading spaces
+	if len(data) < 4 {
+		return 0
+	}
+	i := 0
+	for i < 3 && data[i] == ' ' {
+		i++
+	}
+
+	noteID := 0
+
+	// id part: anything but a newline between brackets
+	if data[i] != '[' {
+		return 0
+	}
+	i++
+	if p.extensions&Footnotes != 0 {
+		if i < len(data) && data[i] == '^' {
+			// we can set it to anything here because the proper noteIds will
+			// be assigned later during the second pass. It just has to be != 0
+			noteID = 1
+			i++
+		}
+	}
+	idOffset := i
+	for i < len(data) && data[i] != '\n' && data[i] != '\r' && data[i] != ']' {
+		i++
+	}
+	if i >= len(data) || data[i] != ']' {
+		return 0
+	}
+	idEnd := i
+	// footnotes can have empty ID, like this: [^], but a reference can not be
+	// empty like this: []. Break early if it's not a footnote and there's no ID
+	if noteID == 0 && idOffset == idEnd {
+		return 0
+	}
+	// spacer: colon (space | tab)* newline? (space | tab)*
+	i++
+	if i >= len(data) || data[i] != ':' {
+		return 0
+	}
+	i++
+	for i < len(data) && (data[i] == ' ' || data[i] == '\t') {
+		i++
+	}
+	if i < len(data) && (data[i] == '\n' || data[i] == '\r') {
+		i++
+		if i < len(data) && data[i] == '\n' && data[i-1] == '\r' {
+			i++
+		}
+	}
+	for i < len(data) && (data[i] == ' ' || data[i] == '\t') {
+		i++
+	}
+	if i >= len(data) {
+		return 0
+	}
+
+	var (
+		linkOffset, linkEnd   int
+		titleOffset, titleEnd int
+		lineEnd               int
+		raw                   []byte
+		hasBlock              bool
+	)
+
+	if p.extensions&Footnotes != 0 && noteID != 0 {
+		linkOffset, linkEnd, raw, hasBlock = scanFootnote(p, data, i, tabSize)
+		lineEnd = linkEnd
+	} else {
+		linkOffset, linkEnd, titleOffset, titleEnd, lineEnd = scanLinkRef(p, data, i)
+	}
+	if lineEnd == 0 {
+		return 0
+	}
+
+	// a valid ref has been found
+
+	ref := &reference{
+		noteID:   noteID,
+		hasBlock: hasBlock,
+	}
+
+	if noteID > 0 {
+		// reusing the link field for the id since footnotes don't have links
+		ref.link = data[idOffset:idEnd]
+		// if footnote, it's not really a title, it's the contained text
+		ref.title = raw
+	} else {
+		ref.link = data[linkOffset:linkEnd]
+		ref.title = data[titleOffset:titleEnd]
+	}
+
+	// id matches are case-insensitive
+	id := string(bytes.ToLower(data[idOffset:idEnd]))
+
+	p.refs[id] = ref
+
+	return lineEnd
+}
+
+func scanLinkRef(p *Markdown, data []byte, i int) (linkOffset, linkEnd, titleOffset, titleEnd, lineEnd int) {
+	// link: whitespace-free sequence, optionally between angle brackets
+	if data[i] == '<' {
+		i++
+	}
+	linkOffset = i
+	for i < len(data) && data[i] != ' ' && data[i] != '\t' && data[i] != '\n' && data[i] != '\r' {
+		i++
+	}
+	linkEnd = i
+	if data[linkOffset] == '<' && data[linkEnd-1] == '>' {
+		linkOffset++
+		linkEnd--
+	}
+
+	// optional spacer: (space | tab)* (newline | '\'' | '"' | '(' )
+	for i < len(data) && (data[i] == ' ' || data[i] == '\t') {
+		i++
+	}
+	if i < len(data) && data[i] != '\n' && data[i] != '\r' && data[i] != '\'' && data[i] != '"' && data[i] != '(' {
+		return
+	}
+
+	// compute end-of-line
+	if i >= len(data) || data[i] == '\r' || data[i] == '\n' {
+		lineEnd = i
+	}
+	if i+1 < len(data) && data[i] == '\r' && data[i+1] == '\n' {
+		lineEnd++
+	}
+
+	// optional (space|tab)* spacer after a newline
+	if lineEnd > 0 {
+		i = lineEnd + 1
+		for i < len(data) && (data[i] == ' ' || data[i] == '\t') {
+			i++
+		}
+	}
+
+	// optional title: any non-newline sequence enclosed in '"() alone on its line
+	if i+1 < len(data) && (data[i] == '\'' || data[i] == '"' || data[i] == '(') {
+		i++
+		titleOffset = i
+
+		// look for EOL
+		for i < len(data) && data[i] != '\n' && data[i] != '\r' {
+			i++
+		}
+		if i+1 < len(data) && data[i] == '\n' && data[i+1] == '\r' {
+			titleEnd = i + 1
+		} else {
+			titleEnd = i
+		}
+
+		// step back
+		i--
+		for i > titleOffset && (data[i] == ' ' || data[i] == '\t') {
+			i--
+		}
+		if i > titleOffset && (data[i] == '\'' || data[i] == '"' || data[i] == ')') {
+			lineEnd = titleEnd
+			titleEnd = i
+		}
+	}
+
+	return
+}
+
+// The first bit of this logic is the same as Parser.listItem, but the rest
+// is much simpler. This function simply finds the entire block and shifts it
+// over by one tab if it is indeed a block (just returns the line if it's not).
+// blockEnd is the end of the section in the input buffer, and contents is the
+// extracted text that was shifted over one tab. It will need to be rendered at
+// the end of the document.
+func scanFootnote(p *Markdown, data []byte, i, indentSize int) (blockStart, blockEnd int, contents []byte, hasBlock bool) {
+	if i == 0 || len(data) == 0 {
+		return
+	}
+
+	// skip leading whitespace on first line
+	for i < len(data) && data[i] == ' ' {
+		i++
+	}
+
+	blockStart = i
+
+	// find the end of the line
+	blockEnd = i
+	for i < len(data) && data[i-1] != '\n' {
+		i++
+	}
+
+	// get working buffer
+	var raw bytes.Buffer
+
+	// put the first line into the working buffer
+	raw.Write(data[blockEnd:i])
+	blockEnd = i
+
+	// process the following lines
+	containsBlankLine := false
+
+gatherLines:
+	for blockEnd < len(data) {
+		i++
+
+		// find the end of this line
+		for i < len(data) && data[i-1] != '\n' {
+			i++
+		}
+
+		// if it is an empty line, guess that it is part of this item
+		// and move on to the next line
+		if p.isEmpty(data[blockEnd:i]) > 0 {
+			containsBlankLine = true
+			blockEnd = i
+			continue
+		}
+
+		n := 0
+		if n = isIndented(data[blockEnd:i], indentSize); n == 0 {
+			// this is the end of the block.
+			// we don't want to include this last line in the index.
+			break gatherLines
+		}
+
+		// if there were blank lines before this one, insert a new one now
+		if containsBlankLine {
+			raw.WriteByte('\n')
+			containsBlankLine = false
+		}
+
+		// get rid of that first tab, write to buffer
+		raw.Write(data[blockEnd+n : i])
+		hasBlock = true
+
+		blockEnd = i
+	}
+
+	if data[blockEnd-1] != '\n' {
+		raw.WriteByte('\n')
+	}
+
+	contents = raw.Bytes()
+
+	return
+}
+
+//
+//
+// Miscellaneous helper functions
+//
+//
+
+// Test if a character is a punctuation symbol.
+// Taken from a private function in regexp in the stdlib.
+func ispunct(c byte) bool {
+	for _, r := range []byte("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~") {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}
+
+// Test if a character is a whitespace character.
+func isspace(c byte) bool {
+	return ishorizontalspace(c) || isverticalspace(c)
+}
+
+// Test if a character is a horizontal whitespace character.
+func ishorizontalspace(c byte) bool {
+	return c == ' ' || c == '\t'
+}
+
+// Test if a character is a vertical character.
+func isverticalspace(c byte) bool {
+	return c == '\n' || c == '\r' || c == '\f' || c == '\v'
+}
+
+// Test if a character is letter.
+func isletter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// Test if a character is a letter or a digit.
+// TODO: check when this is looking for ASCII alnum and when it should use unicode
+func isalnum(c byte) bool {
+	return (c >= '0' && c <= '9') || isletter(c)
+}
+
+// Replace tab characters with spaces, aligning to the next TAB_SIZE column.
+// always ends output with a newline
+func expandTabs(out *bytes.Buffer, line []byte, tabSize int) {
+	// first, check for common cases: no tabs, or only tabs at beginning of line
+	i, prefix := 0, 0
+	slowcase := false
+	for i = 0; i < len(line); i++ {
+		if line[i] == '\t' {
+			if prefix == i {
+				prefix++
+			} else {
+				slowcase = true
+				break
+			}
+		}
+	}
+
+	// no need to decode runes if all tabs are at the beginning of the line
+	if !slowcase {
+		for i = 0; i < prefix*tabSize; i++ {
+			out.WriteByte(' ')
+		}
+		out.Write(line[prefix:])
+		return
+	}
+
+	// the slow case: we need to count runes to figure out how
+	// many spaces to insert for each tab
+	column := 0
+	i = 0
+	for i < len(line) {
+		start := i
+		for i < len(line) && line[i] != '\t' {
+			_, size := utf8.DecodeRune(line[i:])
+			i += size
+			column++
+		}
+
+		if i > start {
+			out.Write(line[start:i])
+		}
+
+		if i >= len(line) {
+			break
+		}
+
+		for {
+			out.WriteByte(' ')
+			column++
+			if column%tabSize == 0 {
+				break
+			}
+		}
+
+		i++
+	}
+}
+
+// Find if a line counts as indented or not.
+// Returns number of characters the indent is (0 = not indented).
+func isIndented(data []byte, indentSize int) int {
+	if len(data) == 0 {
+		return 0
+	}
+	if data[0] == '\t' {
+		return 1
+	}
+	if len(data) < indentSize {
+		return 0
+	}
+	for i := 0; i < indentSize; i++ {
+		if data[i] != ' ' {
+			return 0
+		}
+	}
+	return indentSize
+}
+
+// Create a url-safe slug for fragments
+func slugify(in []byte) []byte {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]byte, 0, len(in))
+	sym := false
+
+	for _, ch := range in {
+		if isalnum(ch) {
+			sym = false
+			out = append(out, ch)
+		} else if sym {
+			continue
+		} else {
+			out = append(out, '-')
+			sym = true
+		}
+	}
+	var a, b int
+	var ch byte
+	for a, ch = range out {
+		if ch != '-' {
+			break
+		}
+	}
+	for b = len(out) - 1; b > 0; b-- {
+		if out[b] != '-' {
+			break
+		}
+	}
+	return out[a : b+1]
+}

--- a/vendor/github.com/russross/blackfriday/v2/node.go
+++ b/vendor/github.com/russross/blackfriday/v2/node.go
@@ -1,0 +1,354 @@
+package blackfriday
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// NodeType specifies a type of a single node of a syntax tree. Usually one
+// node (and its type) corresponds to a single markdown feature, e.g. emphasis
+// or code block.
+type NodeType int
+
+// Constants for identifying different types of nodes. See NodeType.
+const (
+	Document NodeType = iota
+	BlockQuote
+	List
+	Item
+	Paragraph
+	Heading
+	HorizontalRule
+	Emph
+	Strong
+	Del
+	Link
+	Image
+	Text
+	HTMLBlock
+	CodeBlock
+	Softbreak
+	Hardbreak
+	Code
+	HTMLSpan
+	Table
+	TableCell
+	TableHead
+	TableBody
+	TableRow
+)
+
+var nodeTypeNames = []string{
+	Document:       "Document",
+	BlockQuote:     "BlockQuote",
+	List:           "List",
+	Item:           "Item",
+	Paragraph:      "Paragraph",
+	Heading:        "Heading",
+	HorizontalRule: "HorizontalRule",
+	Emph:           "Emph",
+	Strong:         "Strong",
+	Del:            "Del",
+	Link:           "Link",
+	Image:          "Image",
+	Text:           "Text",
+	HTMLBlock:      "HTMLBlock",
+	CodeBlock:      "CodeBlock",
+	Softbreak:      "Softbreak",
+	Hardbreak:      "Hardbreak",
+	Code:           "Code",
+	HTMLSpan:       "HTMLSpan",
+	Table:          "Table",
+	TableCell:      "TableCell",
+	TableHead:      "TableHead",
+	TableBody:      "TableBody",
+	TableRow:       "TableRow",
+}
+
+func (t NodeType) String() string {
+	return nodeTypeNames[t]
+}
+
+// ListData contains fields relevant to a List and Item node type.
+type ListData struct {
+	ListFlags       ListType
+	Tight           bool   // Skip <p>s around list item data if true
+	BulletChar      byte   // '*', '+' or '-' in bullet lists
+	Delimiter       byte   // '.' or ')' after the number in ordered lists
+	RefLink         []byte // If not nil, turns this list item into a footnote item and triggers different rendering
+	IsFootnotesList bool   // This is a list of footnotes
+}
+
+// LinkData contains fields relevant to a Link node type.
+type LinkData struct {
+	Destination []byte // Destination is what goes into a href
+	Title       []byte // Title is the tooltip thing that goes in a title attribute
+	NoteID      int    // NoteID contains a serial number of a footnote, zero if it's not a footnote
+	Footnote    *Node  // If it's a footnote, this is a direct link to the footnote Node. Otherwise nil.
+}
+
+// CodeBlockData contains fields relevant to a CodeBlock node type.
+type CodeBlockData struct {
+	IsFenced    bool   // Specifies whether it's a fenced code block or an indented one
+	Info        []byte // This holds the info string
+	FenceChar   byte
+	FenceLength int
+	FenceOffset int
+}
+
+// TableCellData contains fields relevant to a TableCell node type.
+type TableCellData struct {
+	IsHeader bool           // This tells if it's under the header row
+	Align    CellAlignFlags // This holds the value for align attribute
+}
+
+// HeadingData contains fields relevant to a Heading node type.
+type HeadingData struct {
+	Level        int    // This holds the heading level number
+	HeadingID    string // This might hold heading ID, if present
+	IsTitleblock bool   // Specifies whether it's a title block
+}
+
+// Node is a single element in the abstract syntax tree of the parsed document.
+// It holds connections to the structurally neighboring nodes and, for certain
+// types of nodes, additional information that might be needed when rendering.
+type Node struct {
+	Type       NodeType // Determines the type of the node
+	Parent     *Node    // Points to the parent
+	FirstChild *Node    // Points to the first child, if any
+	LastChild  *Node    // Points to the last child, if any
+	Prev       *Node    // Previous sibling; nil if it's the first child
+	Next       *Node    // Next sibling; nil if it's the last child
+
+	Literal []byte // Text contents of the leaf nodes
+
+	HeadingData   // Populated if Type is Heading
+	ListData      // Populated if Type is List
+	CodeBlockData // Populated if Type is CodeBlock
+	LinkData      // Populated if Type is Link
+	TableCellData // Populated if Type is TableCell
+
+	content []byte // Markdown content of the block nodes
+	open    bool   // Specifies an open block node that has not been finished to process yet
+}
+
+// NewNode allocates a node of a specified type.
+func NewNode(typ NodeType) *Node {
+	return &Node{
+		Type: typ,
+		open: true,
+	}
+}
+
+func (n *Node) String() string {
+	ellipsis := ""
+	snippet := n.Literal
+	if len(snippet) > 16 {
+		snippet = snippet[:16]
+		ellipsis = "..."
+	}
+	return fmt.Sprintf("%s: '%s%s'", n.Type, snippet, ellipsis)
+}
+
+// Unlink removes node 'n' from the tree.
+// It panics if the node is nil.
+func (n *Node) Unlink() {
+	if n.Prev != nil {
+		n.Prev.Next = n.Next
+	} else if n.Parent != nil {
+		n.Parent.FirstChild = n.Next
+	}
+	if n.Next != nil {
+		n.Next.Prev = n.Prev
+	} else if n.Parent != nil {
+		n.Parent.LastChild = n.Prev
+	}
+	n.Parent = nil
+	n.Next = nil
+	n.Prev = nil
+}
+
+// AppendChild adds a node 'child' as a child of 'n'.
+// It panics if either node is nil.
+func (n *Node) AppendChild(child *Node) {
+	child.Unlink()
+	child.Parent = n
+	if n.LastChild != nil {
+		n.LastChild.Next = child
+		child.Prev = n.LastChild
+		n.LastChild = child
+	} else {
+		n.FirstChild = child
+		n.LastChild = child
+	}
+}
+
+// InsertBefore inserts 'sibling' immediately before 'n'.
+// It panics if either node is nil.
+func (n *Node) InsertBefore(sibling *Node) {
+	sibling.Unlink()
+	sibling.Prev = n.Prev
+	if sibling.Prev != nil {
+		sibling.Prev.Next = sibling
+	}
+	sibling.Next = n
+	n.Prev = sibling
+	sibling.Parent = n.Parent
+	if sibling.Prev == nil {
+		sibling.Parent.FirstChild = sibling
+	}
+}
+
+func (n *Node) isContainer() bool {
+	switch n.Type {
+	case Document:
+		fallthrough
+	case BlockQuote:
+		fallthrough
+	case List:
+		fallthrough
+	case Item:
+		fallthrough
+	case Paragraph:
+		fallthrough
+	case Heading:
+		fallthrough
+	case Emph:
+		fallthrough
+	case Strong:
+		fallthrough
+	case Del:
+		fallthrough
+	case Link:
+		fallthrough
+	case Image:
+		fallthrough
+	case Table:
+		fallthrough
+	case TableHead:
+		fallthrough
+	case TableBody:
+		fallthrough
+	case TableRow:
+		fallthrough
+	case TableCell:
+		return true
+	default:
+		return false
+	}
+}
+
+func (n *Node) canContain(t NodeType) bool {
+	if n.Type == List {
+		return t == Item
+	}
+	if n.Type == Document || n.Type == BlockQuote || n.Type == Item {
+		return t != Item
+	}
+	if n.Type == Table {
+		return t == TableHead || t == TableBody
+	}
+	if n.Type == TableHead || n.Type == TableBody {
+		return t == TableRow
+	}
+	if n.Type == TableRow {
+		return t == TableCell
+	}
+	return false
+}
+
+// WalkStatus allows NodeVisitor to have some control over the tree traversal.
+// It is returned from NodeVisitor and different values allow Node.Walk to
+// decide which node to go to next.
+type WalkStatus int
+
+const (
+	// GoToNext is the default traversal of every node.
+	GoToNext WalkStatus = iota
+	// SkipChildren tells walker to skip all children of current node.
+	SkipChildren
+	// Terminate tells walker to terminate the traversal.
+	Terminate
+)
+
+// NodeVisitor is a callback to be called when traversing the syntax tree.
+// Called twice for every node: once with entering=true when the branch is
+// first visited, then with entering=false after all the children are done.
+type NodeVisitor func(node *Node, entering bool) WalkStatus
+
+// Walk is a convenience method that instantiates a walker and starts a
+// traversal of subtree rooted at n.
+func (n *Node) Walk(visitor NodeVisitor) {
+	w := newNodeWalker(n)
+	for w.current != nil {
+		status := visitor(w.current, w.entering)
+		switch status {
+		case GoToNext:
+			w.next()
+		case SkipChildren:
+			w.entering = false
+			w.next()
+		case Terminate:
+			return
+		}
+	}
+}
+
+type nodeWalker struct {
+	current  *Node
+	root     *Node
+	entering bool
+}
+
+func newNodeWalker(root *Node) *nodeWalker {
+	return &nodeWalker{
+		current:  root,
+		root:     root,
+		entering: true,
+	}
+}
+
+func (nw *nodeWalker) next() {
+	if (!nw.current.isContainer() || !nw.entering) && nw.current == nw.root {
+		nw.current = nil
+		return
+	}
+	if nw.entering && nw.current.isContainer() {
+		if nw.current.FirstChild != nil {
+			nw.current = nw.current.FirstChild
+			nw.entering = true
+		} else {
+			nw.entering = false
+		}
+	} else if nw.current.Next == nil {
+		nw.current = nw.current.Parent
+		nw.entering = false
+	} else {
+		nw.current = nw.current.Next
+		nw.entering = true
+	}
+}
+
+func dump(ast *Node) {
+	fmt.Println(dumpString(ast))
+}
+
+func dumpR(ast *Node, depth int) string {
+	if ast == nil {
+		return ""
+	}
+	indent := bytes.Repeat([]byte("\t"), depth)
+	content := ast.Literal
+	if content == nil {
+		content = ast.content
+	}
+	result := fmt.Sprintf("%s%s(%q)\n", indent, ast.Type, content)
+	for n := ast.FirstChild; n != nil; n = n.Next {
+		result += dumpR(n, depth+1)
+	}
+	return result
+}
+
+func dumpString(ast *Node) string {
+	return dumpR(ast, 0)
+}

--- a/vendor/github.com/russross/blackfriday/v2/smartypants.go
+++ b/vendor/github.com/russross/blackfriday/v2/smartypants.go
@@ -1,0 +1,457 @@
+//
+// Blackfriday Markdown Processor
+// Available at http://github.com/russross/blackfriday
+//
+// Copyright © 2011 Russ Ross <russ@russross.com>.
+// Distributed under the Simplified BSD License.
+// See README.md for details.
+//
+
+//
+//
+// SmartyPants rendering
+//
+//
+
+package blackfriday
+
+import (
+	"bytes"
+	"io"
+)
+
+// SPRenderer is a struct containing state of a Smartypants renderer.
+type SPRenderer struct {
+	inSingleQuote bool
+	inDoubleQuote bool
+	callbacks     [256]smartCallback
+}
+
+func wordBoundary(c byte) bool {
+	return c == 0 || isspace(c) || ispunct(c)
+}
+
+func tolower(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c - 'A' + 'a'
+	}
+	return c
+}
+
+func isdigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func smartQuoteHelper(out *bytes.Buffer, previousChar byte, nextChar byte, quote byte, isOpen *bool, addNBSP bool) bool {
+	// edge of the buffer is likely to be a tag that we don't get to see,
+	// so we treat it like text sometimes
+
+	// enumerate all sixteen possibilities for (previousChar, nextChar)
+	// each can be one of {0, space, punct, other}
+	switch {
+	case previousChar == 0 && nextChar == 0:
+		// context is not any help here, so toggle
+		*isOpen = !*isOpen
+	case isspace(previousChar) && nextChar == 0:
+		// [ "] might be [ "<code>foo...]
+		*isOpen = true
+	case ispunct(previousChar) && nextChar == 0:
+		// [!"] hmm... could be [Run!"] or [("<code>...]
+		*isOpen = false
+	case /* isnormal(previousChar) && */ nextChar == 0:
+		// [a"] is probably a close
+		*isOpen = false
+	case previousChar == 0 && isspace(nextChar):
+		// [" ] might be [...foo</code>" ]
+		*isOpen = false
+	case isspace(previousChar) && isspace(nextChar):
+		// [ " ] context is not any help here, so toggle
+		*isOpen = !*isOpen
+	case ispunct(previousChar) && isspace(nextChar):
+		// [!" ] is probably a close
+		*isOpen = false
+	case /* isnormal(previousChar) && */ isspace(nextChar):
+		// [a" ] this is one of the easy cases
+		*isOpen = false
+	case previousChar == 0 && ispunct(nextChar):
+		// ["!] hmm... could be ["$1.95] or [</code>"!...]
+		*isOpen = false
+	case isspace(previousChar) && ispunct(nextChar):
+		// [ "!] looks more like [ "$1.95]
+		*isOpen = true
+	case ispunct(previousChar) && ispunct(nextChar):
+		// [!"!] context is not any help here, so toggle
+		*isOpen = !*isOpen
+	case /* isnormal(previousChar) && */ ispunct(nextChar):
+		// [a"!] is probably a close
+		*isOpen = false
+	case previousChar == 0 /* && isnormal(nextChar) */ :
+		// ["a] is probably an open
+		*isOpen = true
+	case isspace(previousChar) /* && isnormal(nextChar) */ :
+		// [ "a] this is one of the easy cases
+		*isOpen = true
+	case ispunct(previousChar) /* && isnormal(nextChar) */ :
+		// [!"a] is probably an open
+		*isOpen = true
+	default:
+		// [a'b] maybe a contraction?
+		*isOpen = false
+	}
+
+	// Note that with the limited lookahead, this non-breaking
+	// space will also be appended to single double quotes.
+	if addNBSP && !*isOpen {
+		out.WriteString("&nbsp;")
+	}
+
+	out.WriteByte('&')
+	if *isOpen {
+		out.WriteByte('l')
+	} else {
+		out.WriteByte('r')
+	}
+	out.WriteByte(quote)
+	out.WriteString("quo;")
+
+	if addNBSP && *isOpen {
+		out.WriteString("&nbsp;")
+	}
+
+	return true
+}
+
+func (r *SPRenderer) smartSingleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
+	if len(text) >= 2 {
+		t1 := tolower(text[1])
+
+		if t1 == '\'' {
+			nextChar := byte(0)
+			if len(text) >= 3 {
+				nextChar = text[2]
+			}
+			if smartQuoteHelper(out, previousChar, nextChar, 'd', &r.inDoubleQuote, false) {
+				return 1
+			}
+		}
+
+		if (t1 == 's' || t1 == 't' || t1 == 'm' || t1 == 'd') && (len(text) < 3 || wordBoundary(text[2])) {
+			out.WriteString("&rsquo;")
+			return 0
+		}
+
+		if len(text) >= 3 {
+			t2 := tolower(text[2])
+
+			if ((t1 == 'r' && t2 == 'e') || (t1 == 'l' && t2 == 'l') || (t1 == 'v' && t2 == 'e')) &&
+				(len(text) < 4 || wordBoundary(text[3])) {
+				out.WriteString("&rsquo;")
+				return 0
+			}
+		}
+	}
+
+	nextChar := byte(0)
+	if len(text) > 1 {
+		nextChar = text[1]
+	}
+	if smartQuoteHelper(out, previousChar, nextChar, 's', &r.inSingleQuote, false) {
+		return 0
+	}
+
+	out.WriteByte(text[0])
+	return 0
+}
+
+func (r *SPRenderer) smartParens(out *bytes.Buffer, previousChar byte, text []byte) int {
+	if len(text) >= 3 {
+		t1 := tolower(text[1])
+		t2 := tolower(text[2])
+
+		if t1 == 'c' && t2 == ')' {
+			out.WriteString("&copy;")
+			return 2
+		}
+
+		if t1 == 'r' && t2 == ')' {
+			out.WriteString("&reg;")
+			return 2
+		}
+
+		if len(text) >= 4 && t1 == 't' && t2 == 'm' && text[3] == ')' {
+			out.WriteString("&trade;")
+			return 3
+		}
+	}
+
+	out.WriteByte(text[0])
+	return 0
+}
+
+func (r *SPRenderer) smartDash(out *bytes.Buffer, previousChar byte, text []byte) int {
+	if len(text) >= 2 {
+		if text[1] == '-' {
+			out.WriteString("&mdash;")
+			return 1
+		}
+
+		if wordBoundary(previousChar) && wordBoundary(text[1]) {
+			out.WriteString("&ndash;")
+			return 0
+		}
+	}
+
+	out.WriteByte(text[0])
+	return 0
+}
+
+func (r *SPRenderer) smartDashLatex(out *bytes.Buffer, previousChar byte, text []byte) int {
+	if len(text) >= 3 && text[1] == '-' && text[2] == '-' {
+		out.WriteString("&mdash;")
+		return 2
+	}
+	if len(text) >= 2 && text[1] == '-' {
+		out.WriteString("&ndash;")
+		return 1
+	}
+
+	out.WriteByte(text[0])
+	return 0
+}
+
+func (r *SPRenderer) smartAmpVariant(out *bytes.Buffer, previousChar byte, text []byte, quote byte, addNBSP bool) int {
+	if bytes.HasPrefix(text, []byte("&quot;")) {
+		nextChar := byte(0)
+		if len(text) >= 7 {
+			nextChar = text[6]
+		}
+		if smartQuoteHelper(out, previousChar, nextChar, quote, &r.inDoubleQuote, addNBSP) {
+			return 5
+		}
+	}
+
+	if bytes.HasPrefix(text, []byte("&#0;")) {
+		return 3
+	}
+
+	out.WriteByte('&')
+	return 0
+}
+
+func (r *SPRenderer) smartAmp(angledQuotes, addNBSP bool) func(*bytes.Buffer, byte, []byte) int {
+	var quote byte = 'd'
+	if angledQuotes {
+		quote = 'a'
+	}
+
+	return func(out *bytes.Buffer, previousChar byte, text []byte) int {
+		return r.smartAmpVariant(out, previousChar, text, quote, addNBSP)
+	}
+}
+
+func (r *SPRenderer) smartPeriod(out *bytes.Buffer, previousChar byte, text []byte) int {
+	if len(text) >= 3 && text[1] == '.' && text[2] == '.' {
+		out.WriteString("&hellip;")
+		return 2
+	}
+
+	if len(text) >= 5 && text[1] == ' ' && text[2] == '.' && text[3] == ' ' && text[4] == '.' {
+		out.WriteString("&hellip;")
+		return 4
+	}
+
+	out.WriteByte(text[0])
+	return 0
+}
+
+func (r *SPRenderer) smartBacktick(out *bytes.Buffer, previousChar byte, text []byte) int {
+	if len(text) >= 2 && text[1] == '`' {
+		nextChar := byte(0)
+		if len(text) >= 3 {
+			nextChar = text[2]
+		}
+		if smartQuoteHelper(out, previousChar, nextChar, 'd', &r.inDoubleQuote, false) {
+			return 1
+		}
+	}
+
+	out.WriteByte(text[0])
+	return 0
+}
+
+func (r *SPRenderer) smartNumberGeneric(out *bytes.Buffer, previousChar byte, text []byte) int {
+	if wordBoundary(previousChar) && previousChar != '/' && len(text) >= 3 {
+		// is it of the form digits/digits(word boundary)?, i.e., \d+/\d+\b
+		// note: check for regular slash (/) or fraction slash (⁄, 0x2044, or 0xe2 81 84 in utf-8)
+		//       and avoid changing dates like 1/23/2005 into fractions.
+		numEnd := 0
+		for len(text) > numEnd && isdigit(text[numEnd]) {
+			numEnd++
+		}
+		if numEnd == 0 {
+			out.WriteByte(text[0])
+			return 0
+		}
+		denStart := numEnd + 1
+		if len(text) > numEnd+3 && text[numEnd] == 0xe2 && text[numEnd+1] == 0x81 && text[numEnd+2] == 0x84 {
+			denStart = numEnd + 3
+		} else if len(text) < numEnd+2 || text[numEnd] != '/' {
+			out.WriteByte(text[0])
+			return 0
+		}
+		denEnd := denStart
+		for len(text) > denEnd && isdigit(text[denEnd]) {
+			denEnd++
+		}
+		if denEnd == denStart {
+			out.WriteByte(text[0])
+			return 0
+		}
+		if len(text) == denEnd || wordBoundary(text[denEnd]) && text[denEnd] != '/' {
+			out.WriteString("<sup>")
+			out.Write(text[:numEnd])
+			out.WriteString("</sup>&frasl;<sub>")
+			out.Write(text[denStart:denEnd])
+			out.WriteString("</sub>")
+			return denEnd - 1
+		}
+	}
+
+	out.WriteByte(text[0])
+	return 0
+}
+
+func (r *SPRenderer) smartNumber(out *bytes.Buffer, previousChar byte, text []byte) int {
+	if wordBoundary(previousChar) && previousChar != '/' && len(text) >= 3 {
+		if text[0] == '1' && text[1] == '/' && text[2] == '2' {
+			if len(text) < 4 || wordBoundary(text[3]) && text[3] != '/' {
+				out.WriteString("&frac12;")
+				return 2
+			}
+		}
+
+		if text[0] == '1' && text[1] == '/' && text[2] == '4' {
+			if len(text) < 4 || wordBoundary(text[3]) && text[3] != '/' || (len(text) >= 5 && tolower(text[3]) == 't' && tolower(text[4]) == 'h') {
+				out.WriteString("&frac14;")
+				return 2
+			}
+		}
+
+		if text[0] == '3' && text[1] == '/' && text[2] == '4' {
+			if len(text) < 4 || wordBoundary(text[3]) && text[3] != '/' || (len(text) >= 6 && tolower(text[3]) == 't' && tolower(text[4]) == 'h' && tolower(text[5]) == 's') {
+				out.WriteString("&frac34;")
+				return 2
+			}
+		}
+	}
+
+	out.WriteByte(text[0])
+	return 0
+}
+
+func (r *SPRenderer) smartDoubleQuoteVariant(out *bytes.Buffer, previousChar byte, text []byte, quote byte) int {
+	nextChar := byte(0)
+	if len(text) > 1 {
+		nextChar = text[1]
+	}
+	if !smartQuoteHelper(out, previousChar, nextChar, quote, &r.inDoubleQuote, false) {
+		out.WriteString("&quot;")
+	}
+
+	return 0
+}
+
+func (r *SPRenderer) smartDoubleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
+	return r.smartDoubleQuoteVariant(out, previousChar, text, 'd')
+}
+
+func (r *SPRenderer) smartAngledDoubleQuote(out *bytes.Buffer, previousChar byte, text []byte) int {
+	return r.smartDoubleQuoteVariant(out, previousChar, text, 'a')
+}
+
+func (r *SPRenderer) smartLeftAngle(out *bytes.Buffer, previousChar byte, text []byte) int {
+	i := 0
+
+	for i < len(text) && text[i] != '>' {
+		i++
+	}
+
+	out.Write(text[:i+1])
+	return i
+}
+
+type smartCallback func(out *bytes.Buffer, previousChar byte, text []byte) int
+
+// NewSmartypantsRenderer constructs a Smartypants renderer object.
+func NewSmartypantsRenderer(flags HTMLFlags) *SPRenderer {
+	var (
+		r SPRenderer
+
+		smartAmpAngled      = r.smartAmp(true, false)
+		smartAmpAngledNBSP  = r.smartAmp(true, true)
+		smartAmpRegular     = r.smartAmp(false, false)
+		smartAmpRegularNBSP = r.smartAmp(false, true)
+
+		addNBSP = flags&SmartypantsQuotesNBSP != 0
+	)
+
+	if flags&SmartypantsAngledQuotes == 0 {
+		r.callbacks['"'] = r.smartDoubleQuote
+		if !addNBSP {
+			r.callbacks['&'] = smartAmpRegular
+		} else {
+			r.callbacks['&'] = smartAmpRegularNBSP
+		}
+	} else {
+		r.callbacks['"'] = r.smartAngledDoubleQuote
+		if !addNBSP {
+			r.callbacks['&'] = smartAmpAngled
+		} else {
+			r.callbacks['&'] = smartAmpAngledNBSP
+		}
+	}
+	r.callbacks['\''] = r.smartSingleQuote
+	r.callbacks['('] = r.smartParens
+	if flags&SmartypantsDashes != 0 {
+		if flags&SmartypantsLatexDashes == 0 {
+			r.callbacks['-'] = r.smartDash
+		} else {
+			r.callbacks['-'] = r.smartDashLatex
+		}
+	}
+	r.callbacks['.'] = r.smartPeriod
+	if flags&SmartypantsFractions == 0 {
+		r.callbacks['1'] = r.smartNumber
+		r.callbacks['3'] = r.smartNumber
+	} else {
+		for ch := '1'; ch <= '9'; ch++ {
+			r.callbacks[ch] = r.smartNumberGeneric
+		}
+	}
+	r.callbacks['<'] = r.smartLeftAngle
+	r.callbacks['`'] = r.smartBacktick
+	return &r
+}
+
+// Process is the entry point of the Smartypants renderer.
+func (r *SPRenderer) Process(w io.Writer, text []byte) {
+	mark := 0
+	for i := 0; i < len(text); i++ {
+		if action := r.callbacks[text[i]]; action != nil {
+			if i > mark {
+				w.Write(text[mark:i])
+			}
+			previousChar := byte(0)
+			if i > 0 {
+				previousChar = text[i-1]
+			}
+			var tmp bytes.Buffer
+			i += action(&tmp, previousChar, text[i:])
+			w.Write(tmp.Bytes())
+			mark = i + 1
+		}
+	}
+	if mark < len(text) {
+		w.Write(text[mark:])
+	}
+}

--- a/vendor/github.com/shurcooL/sanitized_anchor_name/.travis.yml
+++ b/vendor/github.com/shurcooL/sanitized_anchor_name/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: go
+go:
+  - 1.x
+  - master
+matrix:
+  allow_failures:
+    - go: master
+  fast_finish: true
+install:
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/vendor/github.com/shurcooL/sanitized_anchor_name/LICENSE
+++ b/vendor/github.com/shurcooL/sanitized_anchor_name/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015 Dmitri Shuralyov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/shurcooL/sanitized_anchor_name/README.md
+++ b/vendor/github.com/shurcooL/sanitized_anchor_name/README.md
@@ -1,0 +1,36 @@
+sanitized_anchor_name
+=====================
+
+[![Build Status](https://travis-ci.org/shurcooL/sanitized_anchor_name.svg?branch=master)](https://travis-ci.org/shurcooL/sanitized_anchor_name) [![GoDoc](https://godoc.org/github.com/shurcooL/sanitized_anchor_name?status.svg)](https://godoc.org/github.com/shurcooL/sanitized_anchor_name)
+
+Package sanitized_anchor_name provides a func to create sanitized anchor names.
+
+Its logic can be reused by multiple packages to create interoperable anchor names
+and links to those anchors.
+
+At this time, it does not try to ensure that generated anchor names
+are unique, that responsibility falls on the caller.
+
+Installation
+------------
+
+```bash
+go get -u github.com/shurcooL/sanitized_anchor_name
+```
+
+Example
+-------
+
+```Go
+anchorName := sanitized_anchor_name.Create("This is a header")
+
+fmt.Println(anchorName)
+
+// Output:
+// this-is-a-header
+```
+
+License
+-------
+
+-	[MIT License](LICENSE)

--- a/vendor/github.com/shurcooL/sanitized_anchor_name/main.go
+++ b/vendor/github.com/shurcooL/sanitized_anchor_name/main.go
@@ -1,0 +1,29 @@
+// Package sanitized_anchor_name provides a func to create sanitized anchor names.
+//
+// Its logic can be reused by multiple packages to create interoperable anchor names
+// and links to those anchors.
+//
+// At this time, it does not try to ensure that generated anchor names
+// are unique, that responsibility falls on the caller.
+package sanitized_anchor_name // import "github.com/shurcooL/sanitized_anchor_name"
+
+import "unicode"
+
+// Create returns a sanitized anchor name for the given text.
+func Create(text string) string {
+	var anchorName []rune
+	var futureDash = false
+	for _, r := range text {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			if futureDash && len(anchorName) > 0 {
+				anchorName = append(anchorName, '-')
+			}
+			futureDash = false
+			anchorName = append(anchorName, unicode.ToLower(r))
+		default:
+			futureDash = true
+		}
+	}
+	return string(anchorName)
+}

--- a/vendor/github.com/urfave/cli/.flake8
+++ b/vendor/github.com/urfave/cli/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/vendor/github.com/urfave/cli/.gitignore
+++ b/vendor/github.com/urfave/cli/.gitignore
@@ -1,0 +1,8 @@
+*.coverprofile
+coverage.txt
+node_modules/
+vendor
+.idea
+/.local/
+/internal/
+/site/

--- a/vendor/github.com/urfave/cli/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/urfave/cli/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting Dan Buch at dan@meatballhat.com. All complaints will be
+reviewed and investigated and will result in a response that is deemed necessary
+and appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident.  Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/vendor/github.com/urfave/cli/LICENSE
+++ b/vendor/github.com/urfave/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Jeremy Saenz & Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/urfave/cli/README.md
+++ b/vendor/github.com/urfave/cli/README.md
@@ -1,0 +1,80 @@
+cli
+===
+
+[![Build Status](https://travis-ci.org/urfave/cli.svg?branch=master)](https://travis-ci.org/urfave/cli)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/rtgk5xufi932pb2v?svg=true)](https://ci.appveyor.com/project/urfave/cli)
+
+[![GoDoc](https://godoc.org/github.com/urfave/cli?status.svg)](https://godoc.org/github.com/urfave/cli)
+[![codebeat](https://codebeat.co/badges/0a8f30aa-f975-404b-b878-5fab3ae1cc5f)](https://codebeat.co/projects/github-com-urfave-cli)
+[![Go Report Card](https://goreportcard.com/badge/urfave/cli)](https://goreportcard.com/report/urfave/cli)
+[![codecov](https://codecov.io/gh/urfave/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/urfave/cli)
+
+cli is a simple, fast, and fun package for building command line apps in Go. The
+goal is to enable developers to write fast and distributable command line
+applications in an expressive way.
+
+## Usage Documentation
+
+Usage documentation exists for each major version
+
+- `v1` - [./docs/v1/manual.md](./docs/v1/manual.md)
+- `v2` - 🚧 documentation for `v2` is WIP 🚧
+
+## Installation
+
+Make sure you have a working Go environment.  Go version 1.10+ is supported.  [See
+the install instructions for Go](http://golang.org/doc/install.html).
+
+### GOPATH
+
+Make sure your `PATH` includes the `$GOPATH/bin` directory so your commands can
+be easily used:
+```
+export PATH=$PATH:$GOPATH/bin
+```
+
+### Supported platforms
+
+cli is tested against multiple versions of Go on Linux, and against the latest
+released version of Go on OS X and Windows.  For full details, see
+[`./.travis.yml`](./.travis.yml) and [`./appveyor.yml`](./appveyor.yml).
+
+### Build tags
+
+You can use the following build tags:
+
+#### `urfave_cli_no_docs`
+
+When set, this removes `ToMarkdown` and `ToMan` methods, so your application
+won't be able to call those. This reduces the resulting binary size by about
+300-400 KB (measured using Go 1.18.1 on Linux/amd64), due to less dependencies.
+
+### Using `v1` releases
+
+```
+$ go get github.com/urfave/cli
+```
+
+```go
+...
+import (
+  "github.com/urfave/cli"
+)
+...
+```
+
+### Using `v2` releases
+
+**Warning**: `v2` is in a pre-release state.
+
+```
+$ go get github.com/urfave/cli.v2
+```
+
+```go
+...
+import (
+  "github.com/urfave/cli.v2" // imports as package "cli"
+)
+...
+```

--- a/vendor/github.com/urfave/cli/app.go
+++ b/vendor/github.com/urfave/cli/app.go
@@ -1,0 +1,531 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+var (
+	changeLogURL            = "https://github.com/urfave/cli/blob/master/CHANGELOG.md"
+	appActionDeprecationURL = fmt.Sprintf("%s#deprecated-cli-app-action-signature", changeLogURL)
+	// unused variable. commented for now. will remove in future if agreed upon by everyone
+	//runAndExitOnErrorDeprecationURL = fmt.Sprintf("%s#deprecated-cli-app-runandexitonerror", changeLogURL)
+
+	contactSysadmin = "This is an error in the application.  Please contact the distributor of this application if this is not you."
+
+	errInvalidActionType = NewExitError("ERROR invalid Action type. "+
+		fmt.Sprintf("Must be `func(*Context`)` or `func(*Context) error).  %s", contactSysadmin)+
+		fmt.Sprintf("See %s", appActionDeprecationURL), 2)
+)
+
+// App is the main structure of a cli application. It is recommended that
+// an app be created with the cli.NewApp() function
+type App struct {
+	// The name of the program. Defaults to path.Base(os.Args[0])
+	Name string
+	// Full name of command for help, defaults to Name
+	HelpName string
+	// Description of the program.
+	Usage string
+	// Text to override the USAGE section of help
+	UsageText string
+	// Description of the program argument format.
+	ArgsUsage string
+	// Version of the program
+	Version string
+	// Description of the program
+	Description string
+	// List of commands to execute
+	Commands []Command
+	// List of flags to parse
+	Flags []Flag
+	// Boolean to enable bash completion commands
+	EnableBashCompletion bool
+	// Boolean to hide built-in help command
+	HideHelp bool
+	// Boolean to hide built-in version flag and the VERSION section of help
+	HideVersion bool
+	// Populate on app startup, only gettable through method Categories()
+	categories CommandCategories
+	// An action to execute when the bash-completion flag is set
+	BashComplete BashCompleteFunc
+	// An action to execute before any subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+
+	// The action to execute when no subcommands are specified
+	// Expects a `cli.ActionFunc` but will accept the *deprecated* signature of `func(*cli.Context) {}`
+	// *Note*: support for the deprecated `Action` signature will be removed in a future version
+	Action interface{}
+
+	// Execute this function if the proper command cannot be found
+	CommandNotFound CommandNotFoundFunc
+	// Execute this function if an usage error occurs
+	OnUsageError OnUsageErrorFunc
+	// Compilation date
+	Compiled time.Time
+	// List of all authors who contributed
+	Authors []Author
+	// Copyright of the binary if any
+	Copyright string
+	// Name of Author (Note: Use App.Authors, this is deprecated)
+	Author string
+	// Email of Author (Note: Use App.Authors, this is deprecated)
+	Email string
+	// Writer writer to write output to
+	Writer io.Writer
+	// ErrWriter writes error output
+	ErrWriter io.Writer
+	// Execute this function to handle ExitErrors. If not provided, HandleExitCoder is provided to
+	// function as a default, so this is optional.
+	ExitErrHandler ExitErrHandlerFunc
+	// Other custom info
+	Metadata map[string]interface{}
+	// Carries a function which returns app specific info.
+	ExtraInfo func() map[string]string
+	// CustomAppHelpTemplate the text template for app help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomAppHelpTemplate string
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguements into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
+
+	didSetup bool
+}
+
+// Tries to find out when this binary was compiled.
+// Returns the current time if it fails to find it.
+func compileTime() time.Time {
+	info, err := os.Stat(os.Args[0])
+	if err != nil {
+		return time.Now()
+	}
+	return info.ModTime()
+}
+
+// NewApp creates a new cli Application with some reasonable defaults for Name,
+// Usage, Version and Action.
+func NewApp() *App {
+	return &App{
+		Name:         filepath.Base(os.Args[0]),
+		HelpName:     filepath.Base(os.Args[0]),
+		Usage:        "A new cli application",
+		UsageText:    "",
+		BashComplete: DefaultAppComplete,
+		Action:       helpCommand.Action,
+		Compiled:     compileTime(),
+		Writer:       os.Stdout,
+	}
+}
+
+// Setup runs initialization code to ensure all data structures are ready for
+// `Run` or inspection prior to `Run`.  It is internally called by `Run`, but
+// will return early if setup has already happened.
+func (a *App) Setup() {
+	if a.didSetup {
+		return
+	}
+
+	a.didSetup = true
+
+	if a.Author != "" || a.Email != "" {
+		a.Authors = append(a.Authors, Author{Name: a.Author, Email: a.Email})
+	}
+
+	var newCmds []Command
+	for _, c := range a.Commands {
+		if c.HelpName == "" {
+			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		}
+		newCmds = append(newCmds, c)
+	}
+	a.Commands = newCmds
+
+	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+		a.Commands = append(a.Commands, helpCommand)
+		if (HelpFlag != BoolFlag{}) {
+			a.appendFlag(HelpFlag)
+		}
+	}
+
+	if a.Version == "" {
+		a.HideVersion = true
+	}
+
+	if !a.HideVersion {
+		a.appendFlag(VersionFlag)
+	}
+
+	a.categories = CommandCategories{}
+	for _, command := range a.Commands {
+		a.categories = a.categories.AddCommand(command.Category, command)
+	}
+	sort.Sort(a.categories)
+
+	if a.Metadata == nil {
+		a.Metadata = make(map[string]interface{})
+	}
+
+	if a.Writer == nil {
+		a.Writer = os.Stdout
+	}
+}
+
+func (a *App) newFlagSet() (*flag.FlagSet, error) {
+	return flagSet(a.Name, a.Flags)
+}
+
+func (a *App) useShortOptionHandling() bool {
+	return a.UseShortOptionHandling
+}
+
+// Run is the entry point to the cli app. Parses the arguments slice and routes
+// to the proper flag/args combination
+func (a *App) Run(arguments []string) (err error) {
+	a.Setup()
+
+	// handle the completion flag separately from the flagset since
+	// completion could be attempted after a flag, but before its value was put
+	// on the command line. this causes the flagset to interpret the completion
+	// flag name as the value of the flag before it which is undesirable
+	// note that we can only do this because the shell autocomplete function
+	// always appends the completion flag at the end of the command
+	shellComplete, arguments := checkShellCompleteFlag(a, arguments)
+
+	set, err := a.newFlagSet()
+	if err != nil {
+		return err
+	}
+
+	err = parseIter(set, a, arguments[1:], shellComplete)
+	nerr := normalizeFlags(a.Flags, set)
+	context := NewContext(a, set, nil)
+	if nerr != nil {
+		_, _ = fmt.Fprintln(a.Writer, nerr)
+		_ = ShowAppHelp(context)
+		return nerr
+	}
+	context.shellComplete = shellComplete
+
+	if checkCompletions(context) {
+		return nil
+	}
+
+	if err != nil {
+		if a.OnUsageError != nil {
+			err := a.OnUsageError(context, err, false)
+			a.handleExitCoder(context, err)
+			return err
+		}
+		_, _ = fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
+		_ = ShowAppHelp(context)
+		return err
+	}
+
+	if !a.HideHelp && checkHelp(context) {
+		_ = ShowAppHelp(context)
+		return nil
+	}
+
+	if !a.HideVersion && checkVersion(context) {
+		ShowVersion(context)
+		return nil
+	}
+
+	cerr := checkRequiredFlags(a.Flags, context)
+	if cerr != nil {
+		_ = ShowAppHelp(context)
+		return cerr
+	}
+
+	if a.After != nil && !context.shellComplete {
+		defer func() {
+			if afterErr := a.After(context); afterErr != nil {
+				if err != nil {
+					err = NewMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	if a.Before != nil && !context.shellComplete {
+		beforeErr := a.Before(context)
+		if beforeErr != nil {
+			a.handleExitCoder(context, beforeErr)
+			err = beforeErr
+			return err
+		}
+	}
+
+	args := context.Args()
+	if args.Present() {
+		name := args.First()
+		c := a.Command(name)
+		if c != nil {
+			return c.Run(context)
+		}
+	}
+
+	if a.Action == nil {
+		a.Action = helpCommand.Action
+	}
+
+	// Run default Action
+	err = HandleAction(a.Action, context)
+
+	a.handleExitCoder(context, err)
+	return err
+}
+
+// RunAndExitOnError calls .Run() and exits non-zero if an error was returned
+//
+// Deprecated: instead you should return an error that fulfills cli.ExitCoder
+// to cli.App.Run. This will cause the application to exit with the given eror
+// code in the cli.ExitCoder
+func (a *App) RunAndExitOnError() {
+	if err := a.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(a.errWriter(), err)
+		OsExiter(1)
+	}
+}
+
+// RunAsSubcommand invokes the subcommand given the context, parses ctx.Args() to
+// generate command-specific flags
+func (a *App) RunAsSubcommand(ctx *Context) (err error) {
+	// append help to commands
+	if len(a.Commands) > 0 {
+		if a.Command(helpCommand.Name) == nil && !a.HideHelp {
+			a.Commands = append(a.Commands, helpCommand)
+			if (HelpFlag != BoolFlag{}) {
+				a.appendFlag(HelpFlag)
+			}
+		}
+	}
+
+	newCmds := []Command{}
+	for _, c := range a.Commands {
+		if c.HelpName == "" {
+			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		}
+		newCmds = append(newCmds, c)
+	}
+	a.Commands = newCmds
+
+	set, err := a.newFlagSet()
+	if err != nil {
+		return err
+	}
+
+	err = parseIter(set, a, ctx.Args().Tail(), ctx.shellComplete)
+	nerr := normalizeFlags(a.Flags, set)
+	context := NewContext(a, set, ctx)
+
+	if nerr != nil {
+		_, _ = fmt.Fprintln(a.Writer, nerr)
+		_, _ = fmt.Fprintln(a.Writer)
+		if len(a.Commands) > 0 {
+			_ = ShowSubcommandHelp(context)
+		} else {
+			_ = ShowCommandHelp(ctx, context.Args().First())
+		}
+		return nerr
+	}
+
+	if checkCompletions(context) {
+		return nil
+	}
+
+	if err != nil {
+		if a.OnUsageError != nil {
+			err = a.OnUsageError(context, err, true)
+			a.handleExitCoder(context, err)
+			return err
+		}
+		_, _ = fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
+		_ = ShowSubcommandHelp(context)
+		return err
+	}
+
+	if len(a.Commands) > 0 {
+		if checkSubcommandHelp(context) {
+			return nil
+		}
+	} else {
+		if checkCommandHelp(ctx, context.Args().First()) {
+			return nil
+		}
+	}
+
+	cerr := checkRequiredFlags(a.Flags, context)
+	if cerr != nil {
+		_ = ShowSubcommandHelp(context)
+		return cerr
+	}
+
+	if a.After != nil && !context.shellComplete {
+		defer func() {
+			afterErr := a.After(context)
+			if afterErr != nil {
+				a.handleExitCoder(context, err)
+				if err != nil {
+					err = NewMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	if a.Before != nil && !context.shellComplete {
+		beforeErr := a.Before(context)
+		if beforeErr != nil {
+			a.handleExitCoder(context, beforeErr)
+			err = beforeErr
+			return err
+		}
+	}
+
+	args := context.Args()
+	if args.Present() {
+		name := args.First()
+		c := a.Command(name)
+		if c != nil {
+			return c.Run(context)
+		}
+	}
+
+	// Run default Action
+	err = HandleAction(a.Action, context)
+
+	a.handleExitCoder(context, err)
+	return err
+}
+
+// Command returns the named command on App. Returns nil if the command does not exist
+func (a *App) Command(name string) *Command {
+	for _, c := range a.Commands {
+		if c.HasName(name) {
+			return &c
+		}
+	}
+
+	return nil
+}
+
+// Categories returns a slice containing all the categories with the commands they contain
+func (a *App) Categories() CommandCategories {
+	return a.categories
+}
+
+// VisibleCategories returns a slice of categories and commands that are
+// Hidden=false
+func (a *App) VisibleCategories() []*CommandCategory {
+	ret := []*CommandCategory{}
+	for _, category := range a.categories {
+		if visible := func() *CommandCategory {
+			for _, command := range category.Commands {
+				if !command.Hidden {
+					return category
+				}
+			}
+			return nil
+		}(); visible != nil {
+			ret = append(ret, visible)
+		}
+	}
+	return ret
+}
+
+// VisibleCommands returns a slice of the Commands with Hidden=false
+func (a *App) VisibleCommands() []Command {
+	var ret []Command
+	for _, command := range a.Commands {
+		if !command.Hidden {
+			ret = append(ret, command)
+		}
+	}
+	return ret
+}
+
+// VisibleFlags returns a slice of the Flags with Hidden=false
+func (a *App) VisibleFlags() []Flag {
+	return visibleFlags(a.Flags)
+}
+
+func (a *App) hasFlag(flag Flag) bool {
+	for _, f := range a.Flags {
+		if flag == f {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (a *App) errWriter() io.Writer {
+	// When the app ErrWriter is nil use the package level one.
+	if a.ErrWriter == nil {
+		return ErrWriter
+	}
+
+	return a.ErrWriter
+}
+
+func (a *App) appendFlag(flag Flag) {
+	if !a.hasFlag(flag) {
+		a.Flags = append(a.Flags, flag)
+	}
+}
+
+func (a *App) handleExitCoder(context *Context, err error) {
+	if a.ExitErrHandler != nil {
+		a.ExitErrHandler(context, err)
+	} else {
+		HandleExitCoder(err)
+	}
+}
+
+// Author represents someone who has contributed to a cli project.
+type Author struct {
+	Name  string // The Authors name
+	Email string // The Authors email
+}
+
+// String makes Author comply to the Stringer interface, to allow an easy print in the templating process
+func (a Author) String() string {
+	e := ""
+	if a.Email != "" {
+		e = " <" + a.Email + ">"
+	}
+
+	return fmt.Sprintf("%v%v", a.Name, e)
+}
+
+// HandleAction attempts to figure out which Action signature was used.  If
+// it's an ActionFunc or a func with the legacy signature for Action, the func
+// is run!
+func HandleAction(action interface{}, context *Context) (err error) {
+	switch a := action.(type) {
+	case ActionFunc:
+		return a(context)
+	case func(*Context) error:
+		return a(context)
+	case func(*Context): // deprecated function signature
+		a(context)
+		return nil
+	}
+
+	return errInvalidActionType
+}

--- a/vendor/github.com/urfave/cli/appveyor.yml
+++ b/vendor/github.com/urfave/cli/appveyor.yml
@@ -1,0 +1,28 @@
+version: "{build}"
+
+os: Windows Server 2016
+
+image: Visual Studio 2017
+
+clone_folder: c:\gopath\src\github.com\urfave\cli
+
+cache:
+  - node_modules
+
+environment:
+  GOPATH: C:\gopath
+  GOVERSION: 1.11.x
+  GO111MODULE: on
+  GOPROXY: https://proxy.golang.org
+
+install:
+  - set PATH=%GOPATH%\bin;C:\go\bin;%PATH%
+  - go version
+  - go env
+  - go get github.com/urfave/gfmrun/cmd/gfmrun
+  - go mod vendor
+
+build_script:
+  - go run build.go vet
+  - go run build.go test
+  - go run build.go gfmrun docs/v1/manual.md

--- a/vendor/github.com/urfave/cli/category.go
+++ b/vendor/github.com/urfave/cli/category.go
@@ -1,0 +1,44 @@
+package cli
+
+// CommandCategories is a slice of *CommandCategory.
+type CommandCategories []*CommandCategory
+
+// CommandCategory is a category containing commands.
+type CommandCategory struct {
+	Name     string
+	Commands Commands
+}
+
+func (c CommandCategories) Less(i, j int) bool {
+	return lexicographicLess(c[i].Name, c[j].Name)
+}
+
+func (c CommandCategories) Len() int {
+	return len(c)
+}
+
+func (c CommandCategories) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// AddCommand adds a command to a category.
+func (c CommandCategories) AddCommand(category string, command Command) CommandCategories {
+	for _, commandCategory := range c {
+		if commandCategory.Name == category {
+			commandCategory.Commands = append(commandCategory.Commands, command)
+			return c
+		}
+	}
+	return append(c, &CommandCategory{Name: category, Commands: []Command{command}})
+}
+
+// VisibleCommands returns a slice of the Commands with Hidden=false
+func (c *CommandCategory) VisibleCommands() []Command {
+	ret := []Command{}
+	for _, command := range c.Commands {
+		if !command.Hidden {
+			ret = append(ret, command)
+		}
+	}
+	return ret
+}

--- a/vendor/github.com/urfave/cli/cli.go
+++ b/vendor/github.com/urfave/cli/cli.go
@@ -1,0 +1,22 @@
+// Package cli provides a minimal framework for creating and organizing command line
+// Go applications. cli is designed to be easy to understand and write, the most simple
+// cli application can be written as follows:
+//   func main() {
+//     cli.NewApp().Run(os.Args)
+//   }
+//
+// Of course this application does not do much, so let's make this an actual application:
+//   func main() {
+//     app := cli.NewApp()
+//     app.Name = "greet"
+//     app.Usage = "say a greeting"
+//     app.Action = func(c *cli.Context) error {
+//       println("Greetings")
+//       return nil
+//     }
+//
+//     app.Run(os.Args)
+//   }
+package cli
+
+//go:generate go run flag-gen/main.go flag-gen/assets_vfsdata.go

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -1,0 +1,384 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Command is a subcommand for a cli.App.
+type Command struct {
+	// The name of the command
+	Name string
+	// short name of the command. Typically one character (deprecated, use `Aliases`)
+	ShortName string
+	// A list of aliases for the command
+	Aliases []string
+	// A short description of the usage of this command
+	Usage string
+	// Custom text to show on USAGE section of help
+	UsageText string
+	// A longer explanation of how the command works
+	Description string
+	// A short description of the arguments of this command
+	ArgsUsage string
+	// The category the command is part of
+	Category string
+	// The function to call when checking for bash command completions
+	BashComplete BashCompleteFunc
+	// An action to execute before any sub-subcommands are run, but after the context is ready
+	// If a non-nil error is returned, no sub-subcommands are run
+	Before BeforeFunc
+	// An action to execute after any subcommands are run, but after the subcommand has finished
+	// It is run even if Action() panics
+	After AfterFunc
+	// The function to call when this command is invoked
+	Action interface{}
+	// TODO: replace `Action: interface{}` with `Action: ActionFunc` once some kind
+	// of deprecation period has passed, maybe?
+
+	// Execute this function if a usage error occurs.
+	OnUsageError OnUsageErrorFunc
+	// List of child commands
+	Subcommands Commands
+	// List of flags to parse
+	Flags []Flag
+	// Treat all flags as normal arguments if true
+	SkipFlagParsing bool
+	// Skip argument reordering which attempts to move flags before arguments,
+	// but only works if all flags appear after all arguments. This behavior was
+	// removed n version 2 since it only works under specific conditions so we
+	// backport here by exposing it as an option for compatibility.
+	SkipArgReorder bool
+	// Boolean to hide built-in help command
+	HideHelp bool
+	// Boolean to hide this command from help or completion
+	Hidden bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguments into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
+
+	// Full name of command for help, defaults to full command name, including parent commands.
+	HelpName        string
+	commandNamePath []string
+
+	// CustomHelpTemplate the text template for the command help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomHelpTemplate string
+}
+
+type CommandsByName []Command
+
+func (c CommandsByName) Len() int {
+	return len(c)
+}
+
+func (c CommandsByName) Less(i, j int) bool {
+	return lexicographicLess(c[i].Name, c[j].Name)
+}
+
+func (c CommandsByName) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// FullName returns the full name of the command.
+// For subcommands this ensures that parent commands are part of the command path
+func (c Command) FullName() string {
+	if c.commandNamePath == nil {
+		return c.Name
+	}
+	return strings.Join(c.commandNamePath, " ")
+}
+
+// Commands is a slice of Command
+type Commands []Command
+
+// Run invokes the command given the context, parses ctx.Args() to generate command-specific flags
+func (c Command) Run(ctx *Context) (err error) {
+	if len(c.Subcommands) > 0 {
+		return c.startApp(ctx)
+	}
+
+	if !c.HideHelp && (HelpFlag != BoolFlag{}) {
+		// append help to flags
+		c.Flags = append(
+			c.Flags,
+			HelpFlag,
+		)
+	}
+
+	if ctx.App.UseShortOptionHandling {
+		c.UseShortOptionHandling = true
+	}
+
+	set, err := c.parseFlags(ctx.Args().Tail(), ctx.shellComplete)
+
+	context := NewContext(ctx.App, set, ctx)
+	context.Command = c
+	if checkCommandCompletions(context, c.Name) {
+		return nil
+	}
+
+	if err != nil {
+		if c.OnUsageError != nil {
+			err := c.OnUsageError(context, err, false)
+			context.App.handleExitCoder(context, err)
+			return err
+		}
+		_, _ = fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
+		_, _ = fmt.Fprintln(context.App.Writer)
+		_ = ShowCommandHelp(context, c.Name)
+		return err
+	}
+
+	if checkCommandHelp(context, c.Name) {
+		return nil
+	}
+
+	cerr := checkRequiredFlags(c.Flags, context)
+	if cerr != nil {
+		_ = ShowCommandHelp(context, c.Name)
+		return cerr
+	}
+
+	if c.After != nil {
+		defer func() {
+			afterErr := c.After(context)
+			if afterErr != nil {
+				context.App.handleExitCoder(context, err)
+				if err != nil {
+					err = NewMultiError(err, afterErr)
+				} else {
+					err = afterErr
+				}
+			}
+		}()
+	}
+
+	if c.Before != nil {
+		err = c.Before(context)
+		if err != nil {
+			context.App.handleExitCoder(context, err)
+			return err
+		}
+	}
+
+	if c.Action == nil {
+		c.Action = helpSubcommand.Action
+	}
+
+	err = HandleAction(c.Action, context)
+
+	if err != nil {
+		context.App.handleExitCoder(context, err)
+	}
+	return err
+}
+
+func (c *Command) parseFlags(args Args, shellComplete bool) (*flag.FlagSet, error) {
+	if c.SkipFlagParsing {
+		set, err := c.newFlagSet()
+		if err != nil {
+			return nil, err
+		}
+
+		return set, set.Parse(append([]string{"--"}, args...))
+	}
+
+	if !c.SkipArgReorder {
+		args = reorderArgs(c.Flags, args)
+	}
+
+	set, err := c.newFlagSet()
+	if err != nil {
+		return nil, err
+	}
+
+	err = parseIter(set, c, args, shellComplete)
+	if err != nil {
+		return nil, err
+	}
+
+	err = normalizeFlags(c.Flags, set)
+	if err != nil {
+		return nil, err
+	}
+
+	return set, nil
+}
+
+func (c *Command) newFlagSet() (*flag.FlagSet, error) {
+	return flagSet(c.Name, c.Flags)
+}
+
+func (c *Command) useShortOptionHandling() bool {
+	return c.UseShortOptionHandling
+}
+
+// reorderArgs moves all flags (via reorderedArgs) before the rest of
+// the arguments (remainingArgs) as this is what flag expects.
+func reorderArgs(commandFlags []Flag, args []string) []string {
+	var remainingArgs, reorderedArgs []string
+
+	nextIndexMayContainValue := false
+	for i, arg := range args {
+
+		// if we're expecting an option-value, check if this arg is a value, in
+		// which case it should be re-ordered next to its associated flag
+		if nextIndexMayContainValue && !argIsFlag(commandFlags, arg) {
+			nextIndexMayContainValue = false
+			reorderedArgs = append(reorderedArgs, arg)
+		} else if arg == "--" {
+			// don't reorder any args after the -- delimiter As described in the POSIX spec:
+			// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
+			// > Guideline 10:
+			// >   The first -- argument that is not an option-argument should be accepted
+			// >   as a delimiter indicating the end of options. Any following arguments
+			// >   should be treated as operands, even if they begin with the '-' character.
+
+			// make sure the "--" delimiter itself is at the start
+			remainingArgs = append([]string{"--"}, remainingArgs...)
+			remainingArgs = append(remainingArgs, args[i+1:]...)
+			break
+			// checks if this is an arg that should be re-ordered
+		} else if argIsFlag(commandFlags, arg) {
+			// we have determined that this is a flag that we should re-order
+			reorderedArgs = append(reorderedArgs, arg)
+			// if this arg does not contain a "=", then the next index may contain the value for this flag
+			nextIndexMayContainValue = !strings.Contains(arg, "=")
+
+			// simply append any remaining args
+		} else {
+			remainingArgs = append(remainingArgs, arg)
+		}
+	}
+
+	return append(reorderedArgs, remainingArgs...)
+}
+
+// argIsFlag checks if an arg is one of our command flags
+func argIsFlag(commandFlags []Flag, arg string) bool {
+	if arg == "-" || arg == "--"{
+		// `-` is never a flag
+		// `--` is an option-value when following a flag, and a delimiter indicating the end of options in other cases.
+		return false
+	}
+	// flags always start with a -
+	if !strings.HasPrefix(arg, "-") {
+		return false
+	}
+	// this line turns `--flag` into `flag`
+	if strings.HasPrefix(arg, "--") {
+		arg = strings.Replace(arg, "-", "", 2)
+	}
+	// this line turns `-flag` into `flag`
+	if strings.HasPrefix(arg, "-") {
+		arg = strings.Replace(arg, "-", "", 1)
+	}
+	// this line turns `flag=value` into `flag`
+	arg = strings.Split(arg, "=")[0]
+	// look through all the flags, to see if the `arg` is one of our flags
+	for _, flag := range commandFlags {
+		for _, key := range strings.Split(flag.GetName(), ",") {
+			key := strings.TrimSpace(key)
+			if key == arg {
+				return true
+			}
+		}
+	}
+	// return false if this arg was not one of our flags
+	return false
+}
+
+// Names returns the names including short names and aliases.
+func (c Command) Names() []string {
+	names := []string{c.Name}
+
+	if c.ShortName != "" {
+		names = append(names, c.ShortName)
+	}
+
+	return append(names, c.Aliases...)
+}
+
+// HasName returns true if Command.Name or Command.ShortName matches given name
+func (c Command) HasName(name string) bool {
+	for _, n := range c.Names() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Command) startApp(ctx *Context) error {
+	app := NewApp()
+	app.Metadata = ctx.App.Metadata
+	app.ExitErrHandler = ctx.App.ExitErrHandler
+	// set the name and usage
+	app.Name = fmt.Sprintf("%s %s", ctx.App.Name, c.Name)
+	if c.HelpName == "" {
+		app.HelpName = c.HelpName
+	} else {
+		app.HelpName = app.Name
+	}
+
+	app.Usage = c.Usage
+	app.Description = c.Description
+	app.ArgsUsage = c.ArgsUsage
+
+	// set CommandNotFound
+	app.CommandNotFound = ctx.App.CommandNotFound
+	app.CustomAppHelpTemplate = c.CustomHelpTemplate
+
+	// set the flags and commands
+	app.Commands = c.Subcommands
+	app.Flags = c.Flags
+	app.HideHelp = c.HideHelp
+
+	app.Version = ctx.App.Version
+	app.HideVersion = ctx.App.HideVersion
+	app.Compiled = ctx.App.Compiled
+	app.Author = ctx.App.Author
+	app.Email = ctx.App.Email
+	app.Writer = ctx.App.Writer
+	app.ErrWriter = ctx.App.ErrWriter
+	app.UseShortOptionHandling = ctx.App.UseShortOptionHandling
+
+	app.categories = CommandCategories{}
+	for _, command := range c.Subcommands {
+		app.categories = app.categories.AddCommand(command.Category, command)
+	}
+
+	sort.Sort(app.categories)
+
+	// bash completion
+	app.EnableBashCompletion = ctx.App.EnableBashCompletion
+	if c.BashComplete != nil {
+		app.BashComplete = c.BashComplete
+	}
+
+	// set the actions
+	app.Before = c.Before
+	app.After = c.After
+	if c.Action != nil {
+		app.Action = c.Action
+	} else {
+		app.Action = helpSubcommand.Action
+	}
+	app.OnUsageError = c.OnUsageError
+
+	for index, cc := range app.Commands {
+		app.Commands[index].commandNamePath = []string{c.Name, cc.Name}
+	}
+
+	return app.RunAsSubcommand(ctx)
+}
+
+// VisibleFlags returns a slice of the Flags with Hidden=false
+func (c Command) VisibleFlags() []Flag {
+	return visibleFlags(c.Flags)
+}

--- a/vendor/github.com/urfave/cli/context.go
+++ b/vendor/github.com/urfave/cli/context.go
@@ -1,0 +1,348 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"syscall"
+)
+
+// Context is a type that is passed through to
+// each Handler action in a cli application. Context
+// can be used to retrieve context-specific Args and
+// parsed command-line options.
+type Context struct {
+	App           *App
+	Command       Command
+	shellComplete bool
+	flagSet       *flag.FlagSet
+	setFlags      map[string]bool
+	parentContext *Context
+}
+
+// NewContext creates a new context. For use in when invoking an App or Command action.
+func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
+	c := &Context{App: app, flagSet: set, parentContext: parentCtx}
+
+	if parentCtx != nil {
+		c.shellComplete = parentCtx.shellComplete
+	}
+
+	return c
+}
+
+// NumFlags returns the number of flags set
+func (c *Context) NumFlags() int {
+	return c.flagSet.NFlag()
+}
+
+// Set sets a context flag to a value.
+func (c *Context) Set(name, value string) error {
+	c.setFlags = nil
+	return c.flagSet.Set(name, value)
+}
+
+// GlobalSet sets a context flag to a value on the global flagset
+func (c *Context) GlobalSet(name, value string) error {
+	globalContext(c).setFlags = nil
+	return globalContext(c).flagSet.Set(name, value)
+}
+
+// IsSet determines if the flag was actually set
+func (c *Context) IsSet(name string) bool {
+	if c.setFlags == nil {
+		c.setFlags = make(map[string]bool)
+
+		c.flagSet.Visit(func(f *flag.Flag) {
+			c.setFlags[f.Name] = true
+		})
+
+		c.flagSet.VisitAll(func(f *flag.Flag) {
+			if _, ok := c.setFlags[f.Name]; ok {
+				return
+			}
+			c.setFlags[f.Name] = false
+		})
+
+		// XXX hack to support IsSet for flags with EnvVar
+		//
+		// There isn't an easy way to do this with the current implementation since
+		// whether a flag was set via an environment variable is very difficult to
+		// determine here. Instead, we intend to introduce a backwards incompatible
+		// change in version 2 to add `IsSet` to the Flag interface to push the
+		// responsibility closer to where the information required to determine
+		// whether a flag is set by non-standard means such as environment
+		// variables is available.
+		//
+		// See https://github.com/urfave/cli/issues/294 for additional discussion
+		flags := c.Command.Flags
+		if c.Command.Name == "" { // cannot == Command{} since it contains slice types
+			if c.App != nil {
+				flags = c.App.Flags
+			}
+		}
+		for _, f := range flags {
+			eachName(f.GetName(), func(name string) {
+				if isSet, ok := c.setFlags[name]; isSet || !ok {
+					// Check if a flag is set
+					if isSet {
+						// If the flag is set, also set its other aliases
+						eachName(f.GetName(), func(name string) {
+							c.setFlags[name] = true
+						})
+					}
+
+					return
+				}
+
+				val := reflect.ValueOf(f)
+				if val.Kind() == reflect.Ptr {
+					val = val.Elem()
+				}
+
+				filePathValue := val.FieldByName("FilePath")
+				if filePathValue.IsValid() {
+					eachName(filePathValue.String(), func(filePath string) {
+						if _, err := os.Stat(filePath); err == nil {
+							c.setFlags[name] = true
+							return
+						}
+					})
+				}
+
+				envVarValue := val.FieldByName("EnvVar")
+				if envVarValue.IsValid() {
+					eachName(envVarValue.String(), func(envVar string) {
+						envVar = strings.TrimSpace(envVar)
+						if _, ok := syscall.Getenv(envVar); ok {
+							c.setFlags[name] = true
+							return
+						}
+					})
+				}
+			})
+		}
+	}
+
+	return c.setFlags[name]
+}
+
+// GlobalIsSet determines if the global flag was actually set
+func (c *Context) GlobalIsSet(name string) bool {
+	ctx := c
+	if ctx.parentContext != nil {
+		ctx = ctx.parentContext
+	}
+
+	for ; ctx != nil; ctx = ctx.parentContext {
+		if ctx.IsSet(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// FlagNames returns a slice of flag names used in this context.
+func (c *Context) FlagNames() (names []string) {
+	for _, f := range c.Command.Flags {
+		name := strings.Split(f.GetName(), ",")[0]
+		if name == "help" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return
+}
+
+// GlobalFlagNames returns a slice of global flag names used by the app.
+func (c *Context) GlobalFlagNames() (names []string) {
+	for _, f := range c.App.Flags {
+		name := strings.Split(f.GetName(), ",")[0]
+		if name == "help" || name == "version" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return
+}
+
+// Parent returns the parent context, if any
+func (c *Context) Parent() *Context {
+	return c.parentContext
+}
+
+// value returns the value of the flag coressponding to `name`
+func (c *Context) value(name string) interface{} {
+	return c.flagSet.Lookup(name).Value.(flag.Getter).Get()
+}
+
+// Args contains apps console arguments
+type Args []string
+
+// Args returns the command line arguments associated with the context.
+func (c *Context) Args() Args {
+	args := Args(c.flagSet.Args())
+	return args
+}
+
+// NArg returns the number of the command line arguments.
+func (c *Context) NArg() int {
+	return len(c.Args())
+}
+
+// Get returns the nth argument, or else a blank string
+func (a Args) Get(n int) string {
+	if len(a) > n {
+		return a[n]
+	}
+	return ""
+}
+
+// First returns the first argument, or else a blank string
+func (a Args) First() string {
+	return a.Get(0)
+}
+
+// Tail returns the rest of the arguments (not the first one)
+// or else an empty string slice
+func (a Args) Tail() []string {
+	if len(a) >= 2 {
+		return []string(a)[1:]
+	}
+	return []string{}
+}
+
+// Present checks if there are any arguments present
+func (a Args) Present() bool {
+	return len(a) != 0
+}
+
+// Swap swaps arguments at the given indexes
+func (a Args) Swap(from, to int) error {
+	if from >= len(a) || to >= len(a) {
+		return errors.New("index out of range")
+	}
+	a[from], a[to] = a[to], a[from]
+	return nil
+}
+
+func globalContext(ctx *Context) *Context {
+	if ctx == nil {
+		return nil
+	}
+
+	for {
+		if ctx.parentContext == nil {
+			return ctx
+		}
+		ctx = ctx.parentContext
+	}
+}
+
+func lookupGlobalFlagSet(name string, ctx *Context) *flag.FlagSet {
+	if ctx.parentContext != nil {
+		ctx = ctx.parentContext
+	}
+	for ; ctx != nil; ctx = ctx.parentContext {
+		if f := ctx.flagSet.Lookup(name); f != nil {
+			return ctx.flagSet
+		}
+	}
+	return nil
+}
+
+func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {
+	switch ff.Value.(type) {
+	case *StringSlice:
+	default:
+		_ = set.Set(name, ff.Value.String())
+	}
+}
+
+func normalizeFlags(flags []Flag, set *flag.FlagSet) error {
+	visited := make(map[string]bool)
+	set.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+	for _, f := range flags {
+		parts := strings.Split(f.GetName(), ",")
+		if len(parts) == 1 {
+			continue
+		}
+		var ff *flag.Flag
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if visited[name] {
+				if ff != nil {
+					return errors.New("Cannot use two forms of the same flag: " + name + " " + ff.Name)
+				}
+				ff = set.Lookup(name)
+			}
+		}
+		if ff == nil {
+			continue
+		}
+		for _, name := range parts {
+			name = strings.Trim(name, " ")
+			if !visited[name] {
+				copyFlag(name, ff, set)
+			}
+		}
+	}
+	return nil
+}
+
+type requiredFlagsErr interface {
+	error
+	getMissingFlags() []string
+}
+
+type errRequiredFlags struct {
+	missingFlags []string
+}
+
+func (e *errRequiredFlags) Error() string {
+	numberOfMissingFlags := len(e.missingFlags)
+	if numberOfMissingFlags == 1 {
+		return fmt.Sprintf("Required flag %q not set", e.missingFlags[0])
+	}
+	joinedMissingFlags := strings.Join(e.missingFlags, ", ")
+	return fmt.Sprintf("Required flags %q not set", joinedMissingFlags)
+}
+
+func (e *errRequiredFlags) getMissingFlags() []string {
+	return e.missingFlags
+}
+
+func checkRequiredFlags(flags []Flag, context *Context) requiredFlagsErr {
+	var missingFlags []string
+	for _, f := range flags {
+		if rf, ok := f.(RequiredFlag); ok && rf.IsRequired() {
+			var flagPresent bool
+			var flagName string
+			for _, key := range strings.Split(f.GetName(), ",") {
+				key = strings.TrimSpace(key)
+				if len(key) > 1 {
+					flagName = key
+				}
+
+				if context.IsSet(key) {
+					flagPresent = true
+				}
+			}
+
+			if !flagPresent && flagName != "" {
+				missingFlags = append(missingFlags, flagName)
+			}
+		}
+	}
+
+	if len(missingFlags) != 0 {
+		return &errRequiredFlags{missingFlags: missingFlags}
+	}
+
+	return nil
+}

--- a/vendor/github.com/urfave/cli/docs.go
+++ b/vendor/github.com/urfave/cli/docs.go
@@ -1,0 +1,151 @@
+//go:build !urfave_cli_no_docs
+// +build !urfave_cli_no_docs
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/cpuguy83/go-md2man/v2/md2man"
+)
+
+// ToMarkdown creates a markdown string for the `*App`
+// The function errors if either parsing or writing of the string fails.
+func (a *App) ToMarkdown() (string, error) {
+	var w bytes.Buffer
+	if err := a.writeDocTemplate(&w); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
+// ToMan creates a man page string for the `*App`
+// The function errors if either parsing or writing of the string fails.
+func (a *App) ToMan() (string, error) {
+	var w bytes.Buffer
+	if err := a.writeDocTemplate(&w); err != nil {
+		return "", err
+	}
+	man := md2man.Render(w.Bytes())
+	return string(man), nil
+}
+
+type cliTemplate struct {
+	App          *App
+	Commands     []string
+	GlobalArgs   []string
+	SynopsisArgs []string
+}
+
+func (a *App) writeDocTemplate(w io.Writer) error {
+	const name = "cli"
+	t, err := template.New(name).Parse(MarkdownDocTemplate)
+	if err != nil {
+		return err
+	}
+	return t.ExecuteTemplate(w, name, &cliTemplate{
+		App:          a,
+		Commands:     prepareCommands(a.Commands, 0),
+		GlobalArgs:   prepareArgsWithValues(a.Flags),
+		SynopsisArgs: prepareArgsSynopsis(a.Flags),
+	})
+}
+
+func prepareCommands(commands []Command, level int) []string {
+	coms := []string{}
+	for i := range commands {
+		command := &commands[i]
+		if command.Hidden {
+			continue
+		}
+		usage := ""
+		if command.Usage != "" {
+			usage = command.Usage
+		}
+
+		prepared := fmt.Sprintf("%s %s\n\n%s\n",
+			strings.Repeat("#", level+2),
+			strings.Join(command.Names(), ", "),
+			usage,
+		)
+
+		flags := prepareArgsWithValues(command.Flags)
+		if len(flags) > 0 {
+			prepared += fmt.Sprintf("\n%s", strings.Join(flags, "\n"))
+		}
+
+		coms = append(coms, prepared)
+
+		// recursevly iterate subcommands
+		if len(command.Subcommands) > 0 {
+			coms = append(
+				coms,
+				prepareCommands(command.Subcommands, level+1)...,
+			)
+		}
+	}
+
+	return coms
+}
+
+func prepareArgsWithValues(flags []Flag) []string {
+	return prepareFlags(flags, ", ", "**", "**", `""`, true)
+}
+
+func prepareArgsSynopsis(flags []Flag) []string {
+	return prepareFlags(flags, "|", "[", "]", "[value]", false)
+}
+
+func prepareFlags(
+	flags []Flag,
+	sep, opener, closer, value string,
+	addDetails bool,
+) []string {
+	args := []string{}
+	for _, f := range flags {
+		flag, ok := f.(DocGenerationFlag)
+		if !ok {
+			continue
+		}
+		modifiedArg := opener
+		for _, s := range strings.Split(flag.GetName(), ",") {
+			trimmed := strings.TrimSpace(s)
+			if len(modifiedArg) > len(opener) {
+				modifiedArg += sep
+			}
+			if len(trimmed) > 1 {
+				modifiedArg += fmt.Sprintf("--%s", trimmed)
+			} else {
+				modifiedArg += fmt.Sprintf("-%s", trimmed)
+			}
+		}
+		modifiedArg += closer
+		if flag.TakesValue() {
+			modifiedArg += fmt.Sprintf("=%s", value)
+		}
+
+		if addDetails {
+			modifiedArg += flagDetails(flag)
+		}
+
+		args = append(args, modifiedArg+"\n")
+
+	}
+	sort.Strings(args)
+	return args
+}
+
+// flagDetails returns a string containing the flags metadata
+func flagDetails(flag DocGenerationFlag) string {
+	description := flag.GetUsage()
+	value := flag.GetValue()
+	if value != "" {
+		description += " (default: " + value + ")"
+	}
+	return ": " + description
+}

--- a/vendor/github.com/urfave/cli/errors.go
+++ b/vendor/github.com/urfave/cli/errors.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// OsExiter is the function used when the app exits. If not set defaults to os.Exit.
+var OsExiter = os.Exit
+
+// ErrWriter is used to write errors to the user. This can be anything
+// implementing the io.Writer interface and defaults to os.Stderr.
+var ErrWriter io.Writer = os.Stderr
+
+// MultiError is an error that wraps multiple errors.
+type MultiError struct {
+	Errors []error
+}
+
+// NewMultiError creates a new MultiError. Pass in one or more errors.
+func NewMultiError(err ...error) MultiError {
+	return MultiError{Errors: err}
+}
+
+// Error implements the error interface.
+func (m MultiError) Error() string {
+	errs := make([]string, len(m.Errors))
+	for i, err := range m.Errors {
+		errs[i] = err.Error()
+	}
+
+	return strings.Join(errs, "\n")
+}
+
+type ErrorFormatter interface {
+	Format(s fmt.State, verb rune)
+}
+
+// ExitCoder is the interface checked by `App` and `Command` for a custom exit
+// code
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+
+// ExitError fulfills both the builtin `error` interface and `ExitCoder`
+type ExitError struct {
+	exitCode int
+	message  interface{}
+}
+
+// NewExitError makes a new *ExitError
+func NewExitError(message interface{}, exitCode int) *ExitError {
+	return &ExitError{
+		exitCode: exitCode,
+		message:  message,
+	}
+}
+
+// Error returns the string message, fulfilling the interface required by
+// `error`
+func (ee *ExitError) Error() string {
+	return fmt.Sprintf("%v", ee.message)
+}
+
+// ExitCode returns the exit code, fulfilling the interface required by
+// `ExitCoder`
+func (ee *ExitError) ExitCode() int {
+	return ee.exitCode
+}
+
+// HandleExitCoder checks if the error fulfills the ExitCoder interface, and if
+// so prints the error to stderr (if it is non-empty) and calls OsExiter with the
+// given exit code.  If the given error is a MultiError, then this func is
+// called on all members of the Errors slice and calls OsExiter with the last exit code.
+func HandleExitCoder(err error) {
+	if err == nil {
+		return
+	}
+
+	if exitErr, ok := err.(ExitCoder); ok {
+		if err.Error() != "" {
+			if _, ok := exitErr.(ErrorFormatter); ok {
+				fmt.Fprintf(ErrWriter, "%+v\n", err)
+			} else {
+				fmt.Fprintln(ErrWriter, err)
+			}
+		}
+		OsExiter(exitErr.ExitCode())
+		return
+	}
+
+	if multiErr, ok := err.(MultiError); ok {
+		code := handleMultiError(multiErr)
+		OsExiter(code)
+		return
+	}
+}
+
+func handleMultiError(multiErr MultiError) int {
+	code := 1
+	for _, merr := range multiErr.Errors {
+		if multiErr2, ok := merr.(MultiError); ok {
+			code = handleMultiError(multiErr2)
+		} else {
+			fmt.Fprintln(ErrWriter, merr)
+			if exitErr, ok := merr.(ExitCoder); ok {
+				code = exitErr.ExitCode()
+			}
+		}
+	}
+	return code
+}

--- a/vendor/github.com/urfave/cli/fish.go
+++ b/vendor/github.com/urfave/cli/fish.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"text/template"
+)
+
+// ToFishCompletion creates a fish completion string for the `*App`
+// The function errors if either parsing or writing of the string fails.
+func (a *App) ToFishCompletion() (string, error) {
+	var w bytes.Buffer
+	if err := a.writeFishCompletionTemplate(&w); err != nil {
+		return "", err
+	}
+	return w.String(), nil
+}
+
+type fishCompletionTemplate struct {
+	App         *App
+	Completions []string
+	AllCommands []string
+}
+
+func (a *App) writeFishCompletionTemplate(w io.Writer) error {
+	const name = "cli"
+	t, err := template.New(name).Parse(FishCompletionTemplate)
+	if err != nil {
+		return err
+	}
+	allCommands := []string{}
+
+	// Add global flags
+	completions := a.prepareFishFlags(a.VisibleFlags(), allCommands)
+
+	// Add help flag
+	if !a.HideHelp {
+		completions = append(
+			completions,
+			a.prepareFishFlags([]Flag{HelpFlag}, allCommands)...,
+		)
+	}
+
+	// Add version flag
+	if !a.HideVersion {
+		completions = append(
+			completions,
+			a.prepareFishFlags([]Flag{VersionFlag}, allCommands)...,
+		)
+	}
+
+	// Add commands and their flags
+	completions = append(
+		completions,
+		a.prepareFishCommands(a.VisibleCommands(), &allCommands, []string{})...,
+	)
+
+	return t.ExecuteTemplate(w, name, &fishCompletionTemplate{
+		App:         a,
+		Completions: completions,
+		AllCommands: allCommands,
+	})
+}
+
+func (a *App) prepareFishCommands(commands []Command, allCommands *[]string, previousCommands []string) []string {
+	completions := []string{}
+	for i := range commands {
+		command := &commands[i]
+
+		if command.Hidden {
+			continue
+		}
+
+		var completion strings.Builder
+		completion.WriteString(fmt.Sprintf(
+			"complete -r -c %s -n '%s' -a '%s'",
+			a.Name,
+			a.fishSubcommandHelper(previousCommands),
+			strings.Join(command.Names(), " "),
+		))
+
+		if command.Usage != "" {
+			completion.WriteString(fmt.Sprintf(" -d '%s'",
+				escapeSingleQuotes(command.Usage)))
+		}
+
+		if !command.HideHelp {
+			completions = append(
+				completions,
+				a.prepareFishFlags([]Flag{HelpFlag}, command.Names())...,
+			)
+		}
+
+		*allCommands = append(*allCommands, command.Names()...)
+		completions = append(completions, completion.String())
+		completions = append(
+			completions,
+			a.prepareFishFlags(command.Flags, command.Names())...,
+		)
+
+		// recursevly iterate subcommands
+		if len(command.Subcommands) > 0 {
+			completions = append(
+				completions,
+				a.prepareFishCommands(
+					command.Subcommands, allCommands, command.Names(),
+				)...,
+			)
+		}
+	}
+
+	return completions
+}
+
+func (a *App) prepareFishFlags(flags []Flag, previousCommands []string) []string {
+	completions := []string{}
+	for _, f := range flags {
+		flag, ok := f.(DocGenerationFlag)
+		if !ok {
+			continue
+		}
+
+		completion := &strings.Builder{}
+		completion.WriteString(fmt.Sprintf(
+			"complete -c %s -n '%s'",
+			a.Name,
+			a.fishSubcommandHelper(previousCommands),
+		))
+
+		fishAddFileFlag(f, completion)
+
+		for idx, opt := range strings.Split(flag.GetName(), ",") {
+			if idx == 0 {
+				completion.WriteString(fmt.Sprintf(
+					" -l %s", strings.TrimSpace(opt),
+				))
+			} else {
+				completion.WriteString(fmt.Sprintf(
+					" -s %s", strings.TrimSpace(opt),
+				))
+
+			}
+		}
+
+		if flag.TakesValue() {
+			completion.WriteString(" -r")
+		}
+
+		if flag.GetUsage() != "" {
+			completion.WriteString(fmt.Sprintf(" -d '%s'",
+				escapeSingleQuotes(flag.GetUsage())))
+		}
+
+		completions = append(completions, completion.String())
+	}
+
+	return completions
+}
+
+func fishAddFileFlag(flag Flag, completion *strings.Builder) {
+	switch f := flag.(type) {
+	case GenericFlag:
+		if f.TakesFile {
+			return
+		}
+	case StringFlag:
+		if f.TakesFile {
+			return
+		}
+	case StringSliceFlag:
+		if f.TakesFile {
+			return
+		}
+	}
+	completion.WriteString(" -f")
+}
+
+func (a *App) fishSubcommandHelper(allCommands []string) string {
+	fishHelper := fmt.Sprintf("__fish_%s_no_subcommand", a.Name)
+	if len(allCommands) > 0 {
+		fishHelper = fmt.Sprintf(
+			"__fish_seen_subcommand_from %s",
+			strings.Join(allCommands, " "),
+		)
+	}
+	return fishHelper
+
+}
+
+func escapeSingleQuotes(input string) string {
+	return strings.Replace(input, `'`, `\'`, -1)
+}

--- a/vendor/github.com/urfave/cli/flag.go
+++ b/vendor/github.com/urfave/cli/flag.go
@@ -1,0 +1,348 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const defaultPlaceholder = "value"
+
+// BashCompletionFlag enables bash-completion for all commands and subcommands
+var BashCompletionFlag Flag = BoolFlag{
+	Name:   "generate-bash-completion",
+	Hidden: true,
+}
+
+// VersionFlag prints the version for the application
+var VersionFlag Flag = BoolFlag{
+	Name:  "version, v",
+	Usage: "print the version",
+}
+
+// HelpFlag prints the help for all commands and subcommands
+// Set to the zero value (BoolFlag{}) to disable flag -- keeps subcommand
+// unless HideHelp is set to true)
+var HelpFlag Flag = BoolFlag{
+	Name:  "help, h",
+	Usage: "show help",
+}
+
+// FlagStringer converts a flag definition to a string. This is used by help
+// to display a flag.
+var FlagStringer FlagStringFunc = stringifyFlag
+
+// FlagNamePrefixer converts a full flag name and its placeholder into the help
+// message flag prefix. This is used by the default FlagStringer.
+var FlagNamePrefixer FlagNamePrefixFunc = prefixedNames
+
+// FlagEnvHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagEnvHinter FlagEnvHintFunc = withEnvHint
+
+// FlagFileHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagFileHinter FlagFileHintFunc = withFileHint
+
+// FlagsByName is a slice of Flag.
+type FlagsByName []Flag
+
+func (f FlagsByName) Len() int {
+	return len(f)
+}
+
+func (f FlagsByName) Less(i, j int) bool {
+	return lexicographicLess(f[i].GetName(), f[j].GetName())
+}
+
+func (f FlagsByName) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+// Flag is a common interface related to parsing flags in cli.
+// For more advanced flag parsing techniques, it is recommended that
+// this interface be implemented.
+type Flag interface {
+	fmt.Stringer
+	// Apply Flag settings to the given flag set
+	Apply(*flag.FlagSet)
+	GetName() string
+}
+
+// RequiredFlag is an interface that allows us to mark flags as required
+// it allows flags required flags to be backwards compatible with the Flag interface
+type RequiredFlag interface {
+	Flag
+
+	IsRequired() bool
+}
+
+// DocGenerationFlag is an interface that allows documentation generation for the flag
+type DocGenerationFlag interface {
+	Flag
+
+	// TakesValue returns true if the flag takes a value, otherwise false
+	TakesValue() bool
+
+	// GetUsage returns the usage string for the flag
+	GetUsage() string
+
+	// GetValue returns the flags value as string representation and an empty
+	// string if the flag takes no value at all.
+	GetValue() string
+}
+
+// errorableFlag is an interface that allows us to return errors during apply
+// it allows flags defined in this library to return errors in a fashion backwards compatible
+// TODO remove in v2 and modify the existing Flag interface to return errors
+type errorableFlag interface {
+	Flag
+
+	ApplyWithError(*flag.FlagSet) error
+}
+
+func flagSet(name string, flags []Flag) (*flag.FlagSet, error) {
+	set := flag.NewFlagSet(name, flag.ContinueOnError)
+
+	for _, f := range flags {
+		//TODO remove in v2 when errorableFlag is removed
+		if ef, ok := f.(errorableFlag); ok {
+			if err := ef.ApplyWithError(set); err != nil {
+				return nil, err
+			}
+		} else {
+			f.Apply(set)
+		}
+	}
+	set.SetOutput(ioutil.Discard)
+	return set, nil
+}
+
+func eachName(longName string, fn func(string)) {
+	parts := strings.Split(longName, ",")
+	for _, name := range parts {
+		name = strings.Trim(name, " ")
+		fn(name)
+	}
+}
+
+func visibleFlags(fl []Flag) []Flag {
+	var visible []Flag
+	for _, f := range fl {
+		field := flagValue(f).FieldByName("Hidden")
+		if !field.IsValid() || !field.Bool() {
+			visible = append(visible, f)
+		}
+	}
+	return visible
+}
+
+func prefixFor(name string) (prefix string) {
+	if len(name) == 1 {
+		prefix = "-"
+	} else {
+		prefix = "--"
+	}
+
+	return
+}
+
+// Returns the placeholder, if any, and the unquoted usage string.
+func unquoteUsage(usage string) (string, string) {
+	for i := 0; i < len(usage); i++ {
+		if usage[i] == '`' {
+			for j := i + 1; j < len(usage); j++ {
+				if usage[j] == '`' {
+					name := usage[i+1 : j]
+					usage = usage[:i] + name + usage[j+1:]
+					return name, usage
+				}
+			}
+			break
+		}
+	}
+	return "", usage
+}
+
+func prefixedNames(fullName, placeholder string) string {
+	var prefixed string
+	parts := strings.Split(fullName, ",")
+	for i, name := range parts {
+		name = strings.Trim(name, " ")
+		prefixed += prefixFor(name) + name
+		if placeholder != "" {
+			prefixed += " " + placeholder
+		}
+		if i < len(parts)-1 {
+			prefixed += ", "
+		}
+	}
+	return prefixed
+}
+
+func withEnvHint(envVar, str string) string {
+	envText := ""
+	if envVar != "" {
+		prefix := "$"
+		suffix := ""
+		sep := ", $"
+		if runtime.GOOS == "windows" {
+			prefix = "%"
+			suffix = "%"
+			sep = "%, %"
+		}
+		envText = " [" + prefix + strings.Join(strings.Split(envVar, ","), sep) + suffix + "]"
+	}
+	return str + envText
+}
+
+func withFileHint(filePath, str string) string {
+	fileText := ""
+	if filePath != "" {
+		fileText = fmt.Sprintf(" [%s]", filePath)
+	}
+	return str + fileText
+}
+
+func flagValue(f Flag) reflect.Value {
+	fv := reflect.ValueOf(f)
+	for fv.Kind() == reflect.Ptr {
+		fv = reflect.Indirect(fv)
+	}
+	return fv
+}
+
+func stringifyFlag(f Flag) string {
+	fv := flagValue(f)
+
+	switch f.(type) {
+	case IntSliceFlag:
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyIntSliceFlag(f.(IntSliceFlag)),
+			),
+		)
+	case Int64SliceFlag:
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyInt64SliceFlag(f.(Int64SliceFlag)),
+			),
+		)
+	case StringSliceFlag:
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyStringSliceFlag(f.(StringSliceFlag)),
+			),
+		)
+	}
+
+	placeholder, usage := unquoteUsage(fv.FieldByName("Usage").String())
+
+	needsPlaceholder := false
+	defaultValueString := ""
+
+	if val := fv.FieldByName("Value"); val.IsValid() {
+		needsPlaceholder = true
+		defaultValueString = fmt.Sprintf(" (default: %v)", val.Interface())
+
+		if val.Kind() == reflect.String && val.String() != "" {
+			defaultValueString = fmt.Sprintf(" (default: %q)", val.String())
+		}
+	}
+
+	if defaultValueString == " (default: )" {
+		defaultValueString = ""
+	}
+
+	if needsPlaceholder && placeholder == "" {
+		placeholder = defaultPlaceholder
+	}
+
+	usageWithDefault := strings.TrimSpace(usage + defaultValueString)
+
+	return FlagFileHinter(
+		fv.FieldByName("FilePath").String(),
+		FlagEnvHinter(
+			fv.FieldByName("EnvVar").String(),
+			FlagNamePrefixer(fv.FieldByName("Name").String(), placeholder)+"\t"+usageWithDefault,
+		),
+	)
+}
+
+func stringifyIntSliceFlag(f IntSliceFlag) string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strconv.Itoa(i))
+		}
+	}
+
+	return stringifySliceFlag(f.Usage, f.Name, defaultVals)
+}
+
+func stringifyInt64SliceFlag(f Int64SliceFlag) string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, i := range f.Value.Value() {
+			defaultVals = append(defaultVals, strconv.FormatInt(i, 10))
+		}
+	}
+
+	return stringifySliceFlag(f.Usage, f.Name, defaultVals)
+}
+
+func stringifyStringSliceFlag(f StringSliceFlag) string {
+	var defaultVals []string
+	if f.Value != nil && len(f.Value.Value()) > 0 {
+		for _, s := range f.Value.Value() {
+			if len(s) > 0 {
+				defaultVals = append(defaultVals, strconv.Quote(s))
+			}
+		}
+	}
+
+	return stringifySliceFlag(f.Usage, f.Name, defaultVals)
+}
+
+func stringifySliceFlag(usage, name string, defaultVals []string) string {
+	placeholder, usage := unquoteUsage(usage)
+	if placeholder == "" {
+		placeholder = defaultPlaceholder
+	}
+
+	defaultVal := ""
+	if len(defaultVals) > 0 {
+		defaultVal = fmt.Sprintf(" (default: %s)", strings.Join(defaultVals, ", "))
+	}
+
+	usageWithDefault := strings.TrimSpace(usage + defaultVal)
+	return FlagNamePrefixer(name, placeholder) + "\t" + usageWithDefault
+}
+
+func flagFromFileEnv(filePath, envName string) (val string, ok bool) {
+	for _, envVar := range strings.Split(envName, ",") {
+		envVar = strings.TrimSpace(envVar)
+		if envVal, ok := syscall.Getenv(envVar); ok {
+			return envVal, true
+		}
+	}
+	for _, fileVar := range strings.Split(filePath, ",") {
+		if fileVar != "" {
+			if data, err := ioutil.ReadFile(fileVar); err == nil {
+				return string(data), true
+			}
+		}
+	}
+	return "", false
+}

--- a/vendor/github.com/urfave/cli/flag_bool.go
+++ b/vendor/github.com/urfave/cli/flag_bool.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// BoolFlag is a flag with type bool
+type BoolFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	Destination *bool
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f BoolFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f BoolFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f BoolFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f BoolFlag) TakesValue() bool {
+	return false
+}
+
+// GetUsage returns the usage string for the flag
+func (f BoolFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f BoolFlag) GetValue() string {
+	return ""
+}
+
+// Bool looks up the value of a local BoolFlag, returns
+// false if not found
+func (c *Context) Bool(name string) bool {
+	return lookupBool(name, c.flagSet)
+}
+
+// GlobalBool looks up the value of a global BoolFlag, returns
+// false if not found
+func (c *Context) GlobalBool(name string) bool {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupBool(name, fs)
+	}
+	return false
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f BoolFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f BoolFlag) ApplyWithError(set *flag.FlagSet) error {
+	val := false
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if envVal == "" {
+			val = false
+		} else {
+			envValBool, err := strconv.ParseBool(envVal)
+			if err != nil {
+				return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
+			}
+			val = envValBool
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.BoolVar(f.Destination, name, val, f.Usage)
+			return
+		}
+		set.Bool(name, val, f.Usage)
+	})
+
+	return nil
+}
+
+func lookupBool(name string, set *flag.FlagSet) bool {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return false
+		}
+		return parsed
+	}
+	return false
+}

--- a/vendor/github.com/urfave/cli/flag_bool_t.go
+++ b/vendor/github.com/urfave/cli/flag_bool_t.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// BoolTFlag is a flag with type bool that is true by default
+type BoolTFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	Destination *bool
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f BoolTFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f BoolTFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f BoolTFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f BoolTFlag) TakesValue() bool {
+	return false
+}
+
+// GetUsage returns the usage string for the flag
+func (f BoolTFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f BoolTFlag) GetValue() string {
+	return ""
+}
+
+// BoolT looks up the value of a local BoolTFlag, returns
+// false if not found
+func (c *Context) BoolT(name string) bool {
+	return lookupBoolT(name, c.flagSet)
+}
+
+// GlobalBoolT looks up the value of a global BoolTFlag, returns
+// false if not found
+func (c *Context) GlobalBoolT(name string) bool {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupBoolT(name, fs)
+	}
+	return false
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f BoolTFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f BoolTFlag) ApplyWithError(set *flag.FlagSet) error {
+	val := true
+
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if envVal == "" {
+			val = false
+		} else {
+			envValBool, err := strconv.ParseBool(envVal)
+			if err != nil {
+				return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
+			}
+			val = envValBool
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.BoolVar(f.Destination, name, val, f.Usage)
+			return
+		}
+		set.Bool(name, val, f.Usage)
+	})
+
+	return nil
+}
+
+func lookupBoolT(name string, set *flag.FlagSet) bool {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return false
+		}
+		return parsed
+	}
+	return false
+}

--- a/vendor/github.com/urfave/cli/flag_duration.go
+++ b/vendor/github.com/urfave/cli/flag_duration.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+// DurationFlag is a flag with type time.Duration (see https://golang.org/pkg/time/#ParseDuration)
+type DurationFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	Value       time.Duration
+	Destination *time.Duration
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f DurationFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f DurationFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f DurationFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f DurationFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f DurationFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f DurationFlag) GetValue() string {
+	return f.Value.String()
+}
+
+// Duration looks up the value of a local DurationFlag, returns
+// 0 if not found
+func (c *Context) Duration(name string) time.Duration {
+	return lookupDuration(name, c.flagSet)
+}
+
+// GlobalDuration looks up the value of a global DurationFlag, returns
+// 0 if not found
+func (c *Context) GlobalDuration(name string) time.Duration {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupDuration(name, fs)
+	}
+	return 0
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f DurationFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f DurationFlag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValDuration, err := time.ParseDuration(envVal)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as duration for flag %s: %s", envVal, f.Name, err)
+		}
+
+		f.Value = envValDuration
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.DurationVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Duration(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+func lookupDuration(name string, set *flag.FlagSet) time.Duration {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := time.ParseDuration(f.Value.String())
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/flag_float64.go
+++ b/vendor/github.com/urfave/cli/flag_float64.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// Float64Flag is a flag with type float64
+type Float64Flag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	Value       float64
+	Destination *float64
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f Float64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f Float64Flag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f Float64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f Float64Flag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f Float64Flag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f Float64Flag) GetValue() string {
+	return fmt.Sprintf("%f", f.Value)
+}
+
+// Float64 looks up the value of a local Float64Flag, returns
+// 0 if not found
+func (c *Context) Float64(name string) float64 {
+	return lookupFloat64(name, c.flagSet)
+}
+
+// GlobalFloat64 looks up the value of a global Float64Flag, returns
+// 0 if not found
+func (c *Context) GlobalFloat64(name string) float64 {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupFloat64(name, fs)
+	}
+	return 0
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f Float64Flag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f Float64Flag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValFloat, err := strconv.ParseFloat(envVal, 10)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as float64 value for flag %s: %s", envVal, f.Name, err)
+		}
+
+		f.Value = envValFloat
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.Float64Var(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Float64(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+func lookupFloat64(name string, set *flag.FlagSet) float64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseFloat(f.Value.String(), 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/flag_generic.go
+++ b/vendor/github.com/urfave/cli/flag_generic.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+)
+
+// Generic is a generic parseable type identified by a specific flag
+type Generic interface {
+	Set(value string) error
+	String() string
+}
+
+// GenericFlag is a flag with type Generic
+type GenericFlag struct {
+	Name      string
+	Usage     string
+	EnvVar    string
+	FilePath  string
+	Required  bool
+	Hidden    bool
+	TakesFile bool
+	Value     Generic
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f GenericFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f GenericFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f GenericFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f GenericFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f GenericFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f GenericFlag) GetValue() string {
+	if f.Value != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// Apply takes the flagset and calls Set on the generic flag with the value
+// provided by the user for parsing by the flag
+// Ignores parsing errors
+func (f GenericFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError takes the flagset and calls Set on the generic flag with the value
+// provided by the user for parsing by the flag
+func (f GenericFlag) ApplyWithError(set *flag.FlagSet) error {
+	val := f.Value
+	if fileEnvVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if err := val.Set(fileEnvVal); err != nil {
+			return fmt.Errorf("could not parse %s as value for flag %s: %s", fileEnvVal, f.Name, err)
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		set.Var(f.Value, name, f.Usage)
+	})
+
+	return nil
+}
+
+// Generic looks up the value of a local GenericFlag, returns
+// nil if not found
+func (c *Context) Generic(name string) interface{} {
+	return lookupGeneric(name, c.flagSet)
+}
+
+// GlobalGeneric looks up the value of a global GenericFlag, returns
+// nil if not found
+func (c *Context) GlobalGeneric(name string) interface{} {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupGeneric(name, fs)
+	}
+	return nil
+}
+
+func lookupGeneric(name string, set *flag.FlagSet) interface{} {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := f.Value, error(nil)
+		if err != nil {
+			return nil
+		}
+		return parsed
+	}
+	return nil
+}

--- a/vendor/github.com/urfave/cli/flag_int.go
+++ b/vendor/github.com/urfave/cli/flag_int.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// IntFlag is a flag with type int
+type IntFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	Value       int
+	Destination *int
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f IntFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f IntFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f IntFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f IntFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f IntFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f IntFlag) GetValue() string {
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f IntFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f IntFlag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseInt(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
+		}
+		f.Value = int(envValInt)
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.IntVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Int(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Int looks up the value of a local IntFlag, returns
+// 0 if not found
+func (c *Context) Int(name string) int {
+	return lookupInt(name, c.flagSet)
+}
+
+// GlobalInt looks up the value of a global IntFlag, returns
+// 0 if not found
+func (c *Context) GlobalInt(name string) int {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupInt(name, fs)
+	}
+	return 0
+}
+
+func lookupInt(name string, set *flag.FlagSet) int {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return int(parsed)
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/flag_int64.go
+++ b/vendor/github.com/urfave/cli/flag_int64.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// Int64Flag is a flag with type int64
+type Int64Flag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	Value       int64
+	Destination *int64
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f Int64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f Int64Flag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f Int64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f Int64Flag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f Int64Flag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f Int64Flag) GetValue() string {
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f Int64Flag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f Int64Flag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseInt(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
+		}
+
+		f.Value = envValInt
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.Int64Var(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Int64(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Int64 looks up the value of a local Int64Flag, returns
+// 0 if not found
+func (c *Context) Int64(name string) int64 {
+	return lookupInt64(name, c.flagSet)
+}
+
+// GlobalInt64 looks up the value of a global Int64Flag, returns
+// 0 if not found
+func (c *Context) GlobalInt64(name string) int64 {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupInt64(name, fs)
+	}
+	return 0
+}
+
+func lookupInt64(name string, set *flag.FlagSet) int64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/flag_int64_slice.go
+++ b/vendor/github.com/urfave/cli/flag_int64_slice.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Int64Slice is an opaque type for []int to satisfy flag.Value and flag.Getter
+type Int64Slice []int64
+
+// Set parses the value into an integer and appends it to the list of values
+func (f *Int64Slice) Set(value string) error {
+	tmp, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return err
+	}
+	*f = append(*f, tmp)
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *Int64Slice) String() string {
+	slice := make([]string, len(*f))
+	for i, v := range *f {
+		slice[i] = strconv.FormatInt(v, 10)
+	}
+
+	return strings.Join(slice, ",")
+}
+
+// Value returns the slice of ints set by this flag
+func (f *Int64Slice) Value() []int64 {
+	return *f
+}
+
+// Get returns the slice of ints set by this flag
+func (f *Int64Slice) Get() interface{} {
+	return *f
+}
+
+// Int64SliceFlag is a flag with type *Int64Slice
+type Int64SliceFlag struct {
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Required bool
+	Hidden   bool
+	Value    *Int64Slice
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f Int64SliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f Int64SliceFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f Int64SliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f Int64SliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f Int64SliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f Int64SliceFlag) GetValue() string {
+	if f.Value != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f Int64SliceFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f Int64SliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &Int64Slice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
+			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &Int64Slice{}
+		}
+		set.Var(f.Value, name, f.Usage)
+	})
+
+	return nil
+}
+
+// Int64Slice looks up the value of a local Int64SliceFlag, returns
+// nil if not found
+func (c *Context) Int64Slice(name string) []int64 {
+	return lookupInt64Slice(name, c.flagSet)
+}
+
+// GlobalInt64Slice looks up the value of a global Int64SliceFlag, returns
+// nil if not found
+func (c *Context) GlobalInt64Slice(name string) []int64 {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupInt64Slice(name, fs)
+	}
+	return nil
+}
+
+func lookupInt64Slice(name string, set *flag.FlagSet) []int64 {
+	f := set.Lookup(name)
+	if f != nil {
+		value, ok := f.Value.(*Int64Slice)
+		if !ok {
+			return nil
+		}
+
+		// extract the slice from asserted value
+		parsed := value.Value()
+
+		// extract default value from the flag
+		var defaultVal []int64
+		for _, v := range strings.Split(f.DefValue, ",") {
+			if v != "" {
+				int64Value, err := strconv.ParseInt(v, 10, 64)
+				if err != nil {
+					panic(err)
+				}
+				defaultVal = append(defaultVal, int64Value)
+			}
+		}
+		// if the current value is not equal to the default value
+		// remove the default values from the flag
+		if !isInt64SliceEqual(parsed, defaultVal) {
+			for _, v := range defaultVal {
+				parsed = removeFromInt64Slice(parsed, v)
+			}
+		}
+		return parsed
+	}
+	return nil
+}
+
+func removeFromInt64Slice(slice []int64, val int64) []int64 {
+	for i, v := range slice {
+		if v == val {
+			ret := append([]int64{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
+		}
+	}
+	return slice
+}
+
+func isInt64SliceEqual(newValue, defaultValue []int64) bool {
+	// If one is nil, the other must also be nil.
+	if (newValue == nil) != (defaultValue == nil) {
+		return false
+	}
+
+	if len(newValue) != len(defaultValue) {
+		return false
+	}
+
+	for i, v := range newValue {
+		if v != defaultValue[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/urfave/cli/flag_int_slice.go
+++ b/vendor/github.com/urfave/cli/flag_int_slice.go
@@ -1,0 +1,198 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// IntSlice is an opaque type for []int to satisfy flag.Value and flag.Getter
+type IntSlice []int
+
+// Set parses the value into an integer and appends it to the list of values
+func (f *IntSlice) Set(value string) error {
+	tmp, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	*f = append(*f, tmp)
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *IntSlice) String() string {
+	slice := make([]string, len(*f))
+	for i, v := range *f {
+		slice[i] = strconv.Itoa(v)
+	}
+
+	return strings.Join(slice, ",")
+}
+
+// Value returns the slice of ints set by this flag
+func (f *IntSlice) Value() []int {
+	return *f
+}
+
+// Get returns the slice of ints set by this flag
+func (f *IntSlice) Get() interface{} {
+	return *f
+}
+
+// IntSliceFlag is a flag with type *IntSlice
+type IntSliceFlag struct {
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Required bool
+	Hidden   bool
+	Value    *IntSlice
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f IntSliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f IntSliceFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f IntSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f IntSliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f IntSliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f IntSliceFlag) GetValue() string {
+	if f.Value != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f IntSliceFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f IntSliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &IntSlice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
+			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &IntSlice{}
+		}
+		set.Var(f.Value, name, f.Usage)
+	})
+
+	return nil
+}
+
+// IntSlice looks up the value of a local IntSliceFlag, returns
+// nil if not found
+func (c *Context) IntSlice(name string) []int {
+	return lookupIntSlice(name, c.flagSet)
+}
+
+// GlobalIntSlice looks up the value of a global IntSliceFlag, returns
+// nil if not found
+func (c *Context) GlobalIntSlice(name string) []int {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupIntSlice(name, fs)
+	}
+	return nil
+}
+
+func lookupIntSlice(name string, set *flag.FlagSet) []int {
+	f := set.Lookup(name)
+	if f != nil {
+		value, ok := f.Value.(*IntSlice)
+		if !ok {
+			return nil
+		}
+		// extract the slice from asserted value
+		slice := value.Value()
+
+		// extract default value from the flag
+		var defaultVal []int
+		for _, v := range strings.Split(f.DefValue, ",") {
+			if v != "" {
+				intValue, err := strconv.Atoi(v)
+				if err != nil {
+					panic(err)
+				}
+				defaultVal = append(defaultVal, intValue)
+			}
+		}
+		// if the current value is not equal to the default value
+		// remove the default values from the flag
+		if !isIntSliceEqual(slice, defaultVal) {
+			for _, v := range defaultVal {
+				slice = removeFromIntSlice(slice, v)
+			}
+		}
+		return slice
+	}
+	return nil
+}
+
+func removeFromIntSlice(slice []int, val int) []int {
+	for i, v := range slice {
+		if v == val {
+			ret := append([]int{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
+		}
+	}
+	return slice
+}
+
+func isIntSliceEqual(newValue, defaultValue []int) bool {
+	// If one is nil, the other must also be nil.
+	if (newValue == nil) != (defaultValue == nil) {
+		return false
+	}
+
+	if len(newValue) != len(defaultValue) {
+		return false
+	}
+
+	for i, v := range newValue {
+		if v != defaultValue[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/urfave/cli/flag_string.go
+++ b/vendor/github.com/urfave/cli/flag_string.go
@@ -1,0 +1,98 @@
+package cli
+
+import "flag"
+
+// StringFlag is a flag with type string
+type StringFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	TakesFile   bool
+	Value       string
+	Destination *string
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f StringFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f StringFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f StringFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f StringFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f StringFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f StringFlag) GetValue() string {
+	return f.Value
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f StringFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f StringFlag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		f.Value = envVal
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.StringVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.String(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// String looks up the value of a local StringFlag, returns
+// "" if not found
+func (c *Context) String(name string) string {
+	return lookupString(name, c.flagSet)
+}
+
+// GlobalString looks up the value of a global StringFlag, returns
+// "" if not found
+func (c *Context) GlobalString(name string) string {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupString(name, fs)
+	}
+	return ""
+}
+
+func lookupString(name string, set *flag.FlagSet) string {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := f.Value.String(), error(nil)
+		if err != nil {
+			return ""
+		}
+		return parsed
+	}
+	return ""
+}

--- a/vendor/github.com/urfave/cli/flag_string_slice.go
+++ b/vendor/github.com/urfave/cli/flag_string_slice.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+)
+
+// StringSlice is an opaque type for []string to satisfy flag.Value and flag.Getter
+type StringSlice []string
+
+// Set appends the string value to the list of values
+func (f *StringSlice) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+// String returns a readable representation of this value (for usage defaults)
+func (f *StringSlice) String() string {
+	return strings.Join(*f, ",")
+}
+
+// Value returns the slice of strings set by this flag
+func (f *StringSlice) Value() []string {
+	return *f
+}
+
+// Get returns the slice of strings set by this flag
+func (f *StringSlice) Get() interface{} {
+	return *f
+}
+
+// StringSliceFlag is a flag with type *StringSlice
+type StringSliceFlag struct {
+	Name      string
+	Usage     string
+	EnvVar    string
+	FilePath  string
+	Required  bool
+	Hidden    bool
+	TakesFile bool
+	Value     *StringSlice
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f StringSliceFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f StringSliceFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f StringSliceFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f StringSliceFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f StringSliceFlag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f StringSliceFlag) GetValue() string {
+	if f.Value != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f StringSliceFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f StringSliceFlag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &StringSlice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
+			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
+		}
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Value == nil {
+			f.Value = &StringSlice{}
+		}
+		set.Var(f.Value, name, f.Usage)
+	})
+
+	return nil
+}
+
+// StringSlice looks up the value of a local StringSliceFlag, returns
+// nil if not found
+func (c *Context) StringSlice(name string) []string {
+	return lookupStringSlice(name, c.flagSet)
+}
+
+// GlobalStringSlice looks up the value of a global StringSliceFlag, returns
+// nil if not found
+func (c *Context) GlobalStringSlice(name string) []string {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupStringSlice(name, fs)
+	}
+	return nil
+}
+
+func lookupStringSlice(name string, set *flag.FlagSet) []string {
+	f := set.Lookup(name)
+	if f != nil {
+		value, ok := f.Value.(*StringSlice)
+		if !ok {
+			return nil
+		}
+		// extract the slice from asserted value
+		slice := value.Value()
+
+		// extract default value from the flag
+		var defaultVal []string
+		for _, v := range strings.Split(f.DefValue, ",") {
+			defaultVal = append(defaultVal, v)
+		}
+
+		// if the current value is not equal to the default value
+		// remove the default values from the flag
+		if !isStringSliceEqual(slice, defaultVal) {
+			for _, v := range defaultVal {
+				slice = removeFromStringSlice(slice, v)
+			}
+		}
+		return slice
+	}
+	return nil
+}
+
+func removeFromStringSlice(slice []string, val string) []string {
+	for i, v := range slice {
+		if v == val {
+			ret := append([]string{}, slice[:i]...)
+			ret = append(ret, slice[i+1:]...)
+			return ret
+		}
+	}
+	return slice
+}
+
+func isStringSliceEqual(newValue, defaultValue []string) bool {
+	// If one is nil, the other must also be nil.
+	if (newValue == nil) != (defaultValue == nil) {
+		return false
+	}
+
+	if len(newValue) != len(defaultValue) {
+		return false
+	}
+
+	for i, v := range newValue {
+		if v != defaultValue[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/urfave/cli/flag_uint.go
+++ b/vendor/github.com/urfave/cli/flag_uint.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// UintFlag is a flag with type uint
+type UintFlag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	Value       uint
+	Destination *uint
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f UintFlag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f UintFlag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f UintFlag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f UintFlag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f UintFlag) GetUsage() string {
+	return f.Usage
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f UintFlag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f UintFlag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseUint(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as uint value for flag %s: %s", envVal, f.Name, err)
+		}
+
+		f.Value = uint(envValInt)
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.UintVar(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Uint(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f UintFlag) GetValue() string {
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// Uint looks up the value of a local UintFlag, returns
+// 0 if not found
+func (c *Context) Uint(name string) uint {
+	return lookupUint(name, c.flagSet)
+}
+
+// GlobalUint looks up the value of a global UintFlag, returns
+// 0 if not found
+func (c *Context) GlobalUint(name string) uint {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupUint(name, fs)
+	}
+	return 0
+}
+
+func lookupUint(name string, set *flag.FlagSet) uint {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseUint(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return uint(parsed)
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/flag_uint64.go
+++ b/vendor/github.com/urfave/cli/flag_uint64.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+)
+
+// Uint64Flag is a flag with type uint64
+type Uint64Flag struct {
+	Name        string
+	Usage       string
+	EnvVar      string
+	FilePath    string
+	Required    bool
+	Hidden      bool
+	Value       uint64
+	Destination *uint64
+}
+
+// String returns a readable representation of this value
+// (for usage defaults)
+func (f Uint64Flag) String() string {
+	return FlagStringer(f)
+}
+
+// GetName returns the name of the flag
+func (f Uint64Flag) GetName() string {
+	return f.Name
+}
+
+// IsRequired returns whether or not the flag is required
+func (f Uint64Flag) IsRequired() bool {
+	return f.Required
+}
+
+// TakesValue returns true of the flag takes a value, otherwise false
+func (f Uint64Flag) TakesValue() bool {
+	return true
+}
+
+// GetUsage returns the usage string for the flag
+func (f Uint64Flag) GetUsage() string {
+	return f.Usage
+}
+
+// GetValue returns the flags value as string representation and an empty
+// string if the flag takes no value at all.
+func (f Uint64Flag) GetValue() string {
+	return fmt.Sprintf("%d", f.Value)
+}
+
+// Apply populates the flag given the flag set and environment
+// Ignores errors
+func (f Uint64Flag) Apply(set *flag.FlagSet) {
+	_ = f.ApplyWithError(set)
+}
+
+// ApplyWithError populates the flag given the flag set and environment
+func (f Uint64Flag) ApplyWithError(set *flag.FlagSet) error {
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseUint(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as uint64 value for flag %s: %s", envVal, f.Name, err)
+		}
+
+		f.Value = envValInt
+	}
+
+	eachName(f.Name, func(name string) {
+		if f.Destination != nil {
+			set.Uint64Var(f.Destination, name, f.Value, f.Usage)
+			return
+		}
+		set.Uint64(name, f.Value, f.Usage)
+	})
+
+	return nil
+}
+
+// Uint64 looks up the value of a local Uint64Flag, returns
+// 0 if not found
+func (c *Context) Uint64(name string) uint64 {
+	return lookupUint64(name, c.flagSet)
+}
+
+// GlobalUint64 looks up the value of a global Uint64Flag, returns
+// 0 if not found
+func (c *Context) GlobalUint64(name string) uint64 {
+	if fs := lookupGlobalFlagSet(name, c); fs != nil {
+		return lookupUint64(name, fs)
+	}
+	return 0
+}
+
+func lookupUint64(name string, set *flag.FlagSet) uint64 {
+	f := set.Lookup(name)
+	if f != nil {
+		parsed, err := strconv.ParseUint(f.Value.String(), 0, 64)
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
+}

--- a/vendor/github.com/urfave/cli/funcs.go
+++ b/vendor/github.com/urfave/cli/funcs.go
@@ -1,0 +1,44 @@
+package cli
+
+// BashCompleteFunc is an action to execute when the bash-completion flag is set
+type BashCompleteFunc func(*Context)
+
+// BeforeFunc is an action to execute before any subcommands are run, but after
+// the context is ready if a non-nil error is returned, no subcommands are run
+type BeforeFunc func(*Context) error
+
+// AfterFunc is an action to execute after any subcommands are run, but after the
+// subcommand has finished it is run even if Action() panics
+type AfterFunc func(*Context) error
+
+// ActionFunc is the action to execute when no subcommands are specified
+type ActionFunc func(*Context) error
+
+// CommandNotFoundFunc is executed if the proper command cannot be found
+type CommandNotFoundFunc func(*Context, string)
+
+// OnUsageErrorFunc is executed if an usage error occurs. This is useful for displaying
+// customized usage error messages.  This function is able to replace the
+// original error messages.  If this function is not set, the "Incorrect usage"
+// is displayed and the execution is interrupted.
+type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
+
+// ExitErrHandlerFunc is executed if provided in order to handle ExitError values
+// returned by Actions and Before/After functions.
+type ExitErrHandlerFunc func(context *Context, err error)
+
+// FlagStringFunc is used by the help generation to display a flag, which is
+// expected to be a single line.
+type FlagStringFunc func(Flag) string
+
+// FlagNamePrefixFunc is used by the default FlagStringFunc to create prefix
+// text for a flag's full name.
+type FlagNamePrefixFunc func(fullName, placeholder string) string
+
+// FlagEnvHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the environment variable details.
+type FlagEnvHintFunc func(envVar, str string) string
+
+// FlagFileHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the file path details.
+type FlagFileHintFunc func(filePath, str string) string

--- a/vendor/github.com/urfave/cli/help.go
+++ b/vendor/github.com/urfave/cli/help.go
@@ -1,0 +1,363 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+	"unicode/utf8"
+)
+
+var helpCommand = Command{
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+	Action: func(c *Context) error {
+		args := c.Args()
+		if args.Present() {
+			return ShowCommandHelp(c, args.First())
+		}
+
+		_ = ShowAppHelp(c)
+		return nil
+	},
+}
+
+var helpSubcommand = Command{
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
+	Action: func(c *Context) error {
+		args := c.Args()
+		if args.Present() {
+			return ShowCommandHelp(c, args.First())
+		}
+
+		return ShowSubcommandHelp(c)
+	},
+}
+
+// Prints help for the App or Command
+type helpPrinter func(w io.Writer, templ string, data interface{})
+
+// Prints help for the App or Command with custom template function.
+type helpPrinterCustom func(w io.Writer, templ string, data interface{}, customFunc map[string]interface{})
+
+// HelpPrinter is a function that writes the help output. If not set explicitly,
+// this calls HelpPrinterCustom using only the default template functions.
+//
+// If custom logic for printing help is required, this function can be
+// overridden. If the ExtraInfo field is defined on an App, this function
+// should not be modified, as HelpPrinterCustom will be used directly in order
+// to capture the extra information.
+var HelpPrinter helpPrinter = printHelp
+
+// HelpPrinterCustom is a function that writes the help output. It is used as
+// the default implementation of HelpPrinter, and may be called directly if
+// the ExtraInfo field is set on an App.
+var HelpPrinterCustom helpPrinterCustom = printHelpCustom
+
+// VersionPrinter prints the version for the App
+var VersionPrinter = printVersion
+
+// ShowAppHelpAndExit - Prints the list of subcommands for the app and exits with exit code.
+func ShowAppHelpAndExit(c *Context, exitCode int) {
+	_ = ShowAppHelp(c)
+	os.Exit(exitCode)
+}
+
+// ShowAppHelp is an action that displays the help.
+func ShowAppHelp(c *Context) error {
+	template := c.App.CustomAppHelpTemplate
+	if template == "" {
+		template = AppHelpTemplate
+	}
+
+	if c.App.ExtraInfo == nil {
+		HelpPrinter(c.App.Writer, template, c.App)
+		return nil
+	}
+
+	customAppData := func() map[string]interface{} {
+		return map[string]interface{}{
+			"ExtraInfo": c.App.ExtraInfo,
+		}
+	}
+	HelpPrinterCustom(c.App.Writer, template, c.App, customAppData())
+
+	return nil
+}
+
+// DefaultAppComplete prints the list of subcommands as the default app completion method
+func DefaultAppComplete(c *Context) {
+	DefaultCompleteWithFlags(nil)(c)
+}
+
+func printCommandSuggestions(commands []Command, writer io.Writer) {
+	for _, command := range commands {
+		if command.Hidden {
+			continue
+		}
+		if os.Getenv("_CLI_ZSH_AUTOCOMPLETE_HACK") == "1" {
+			for _, name := range command.Names() {
+				_, _ = fmt.Fprintf(writer, "%s:%s\n", name, command.Usage)
+			}
+		} else {
+			for _, name := range command.Names() {
+				_, _ = fmt.Fprintf(writer, "%s\n", name)
+			}
+		}
+	}
+}
+
+func cliArgContains(flagName string) bool {
+	for _, name := range strings.Split(flagName, ",") {
+		name = strings.TrimSpace(name)
+		count := utf8.RuneCountInString(name)
+		if count > 2 {
+			count = 2
+		}
+		flag := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+		for _, a := range os.Args {
+			if a == flag {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
+	cur := strings.TrimPrefix(lastArg, "-")
+	cur = strings.TrimPrefix(cur, "-")
+	for _, flag := range flags {
+		if bflag, ok := flag.(BoolFlag); ok && bflag.Hidden {
+			continue
+		}
+		for _, name := range strings.Split(flag.GetName(), ",") {
+			name = strings.TrimSpace(name)
+			// this will get total count utf8 letters in flag name
+			count := utf8.RuneCountInString(name)
+			if count > 2 {
+				count = 2 // resuse this count to generate single - or -- in flag completion
+			}
+			// if flag name has more than one utf8 letter and last argument in cli has -- prefix then
+			// skip flag completion for short flags example -v or -x
+			if strings.HasPrefix(lastArg, "--") && count == 1 {
+				continue
+			}
+			// match if last argument matches this flag and it is not repeated
+			if strings.HasPrefix(name, cur) && cur != name && !cliArgContains(flag.GetName()) {
+				flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
+				_, _ = fmt.Fprintln(writer, flagCompletion)
+			}
+		}
+	}
+}
+
+func DefaultCompleteWithFlags(cmd *Command) func(c *Context) {
+	return func(c *Context) {
+		if len(os.Args) > 2 {
+			lastArg := os.Args[len(os.Args)-2]
+			if strings.HasPrefix(lastArg, "-") {
+				printFlagSuggestions(lastArg, c.App.Flags, c.App.Writer)
+				if cmd != nil {
+					printFlagSuggestions(lastArg, cmd.Flags, c.App.Writer)
+				}
+				return
+			}
+		}
+		if cmd != nil {
+			printCommandSuggestions(cmd.Subcommands, c.App.Writer)
+		} else {
+			printCommandSuggestions(c.App.Commands, c.App.Writer)
+		}
+	}
+}
+
+// ShowCommandHelpAndExit - exits with code after showing help
+func ShowCommandHelpAndExit(c *Context, command string, code int) {
+	_ = ShowCommandHelp(c, command)
+	os.Exit(code)
+}
+
+// ShowCommandHelp prints help for the given command
+func ShowCommandHelp(ctx *Context, command string) error {
+	// show the subcommand help for a command with subcommands
+	if command == "" {
+		HelpPrinter(ctx.App.Writer, SubcommandHelpTemplate, ctx.App)
+		return nil
+	}
+
+	for _, c := range ctx.App.Commands {
+		if c.HasName(command) {
+			templ := c.CustomHelpTemplate
+			if templ == "" {
+				templ = CommandHelpTemplate
+			}
+
+			HelpPrinter(ctx.App.Writer, templ, c)
+
+			return nil
+		}
+	}
+
+	if ctx.App.CommandNotFound == nil {
+		return NewExitError(fmt.Sprintf("No help topic for '%v'", command), 3)
+	}
+
+	ctx.App.CommandNotFound(ctx, command)
+	return nil
+}
+
+// ShowSubcommandHelp prints help for the given subcommand
+func ShowSubcommandHelp(c *Context) error {
+	return ShowCommandHelp(c, c.Command.Name)
+}
+
+// ShowVersion prints the version number of the App
+func ShowVersion(c *Context) {
+	VersionPrinter(c)
+}
+
+func printVersion(c *Context) {
+	_, _ = fmt.Fprintf(c.App.Writer, "%v version %v\n", c.App.Name, c.App.Version)
+}
+
+// ShowCompletions prints the lists of commands within a given context
+func ShowCompletions(c *Context) {
+	a := c.App
+	if a != nil && a.BashComplete != nil {
+		a.BashComplete(c)
+	}
+}
+
+// ShowCommandCompletions prints the custom completions for a given command
+func ShowCommandCompletions(ctx *Context, command string) {
+	c := ctx.App.Command(command)
+	if c != nil {
+		if c.BashComplete != nil {
+			c.BashComplete(ctx)
+		} else {
+			DefaultCompleteWithFlags(c)(ctx)
+		}
+	}
+
+}
+
+// printHelpCustom is the default implementation of HelpPrinterCustom.
+//
+// The customFuncs map will be combined with a default template.FuncMap to
+// allow using arbitrary functions in template rendering.
+func printHelpCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
+	funcMap := template.FuncMap{
+		"join": strings.Join,
+	}
+	for key, value := range customFuncs {
+		funcMap[key] = value
+	}
+
+	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)
+	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
+	err := t.Execute(w, data)
+	if err != nil {
+		// If the writer is closed, t.Execute will fail, and there's nothing
+		// we can do to recover.
+		if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
+			_, _ = fmt.Fprintf(ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
+		}
+		return
+	}
+	_ = w.Flush()
+}
+
+func printHelp(out io.Writer, templ string, data interface{}) {
+	HelpPrinterCustom(out, templ, data, nil)
+}
+
+func checkVersion(c *Context) bool {
+	found := false
+	if VersionFlag.GetName() != "" {
+		eachName(VersionFlag.GetName(), func(name string) {
+			if c.GlobalBool(name) || c.Bool(name) {
+				found = true
+			}
+		})
+	}
+	return found
+}
+
+func checkHelp(c *Context) bool {
+	found := false
+	if HelpFlag.GetName() != "" {
+		eachName(HelpFlag.GetName(), func(name string) {
+			if c.GlobalBool(name) || c.Bool(name) {
+				found = true
+			}
+		})
+	}
+	return found
+}
+
+func checkCommandHelp(c *Context, name string) bool {
+	if c.Bool("h") || c.Bool("help") {
+		_ = ShowCommandHelp(c, name)
+		return true
+	}
+
+	return false
+}
+
+func checkSubcommandHelp(c *Context) bool {
+	if c.Bool("h") || c.Bool("help") {
+		_ = ShowSubcommandHelp(c)
+		return true
+	}
+
+	return false
+}
+
+func checkShellCompleteFlag(a *App, arguments []string) (bool, []string) {
+	if !a.EnableBashCompletion {
+		return false, arguments
+	}
+
+	pos := len(arguments) - 1
+	lastArg := arguments[pos]
+
+	if lastArg != "--"+BashCompletionFlag.GetName() {
+		return false, arguments
+	}
+
+	return true, arguments[:pos]
+}
+
+func checkCompletions(c *Context) bool {
+	if !c.shellComplete {
+		return false
+	}
+
+	if args := c.Args(); args.Present() {
+		name := args.First()
+		if cmd := c.App.Command(name); cmd != nil {
+			// let the command handle the completion
+			return false
+		}
+	}
+
+	ShowCompletions(c)
+	return true
+}
+
+func checkCommandCompletions(c *Context, name string) bool {
+	if !c.shellComplete {
+		return false
+	}
+
+	ShowCommandCompletions(c, name)
+	return true
+}

--- a/vendor/github.com/urfave/cli/parse.go
+++ b/vendor/github.com/urfave/cli/parse.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"flag"
+	"strings"
+)
+
+type iterativeParser interface {
+	newFlagSet() (*flag.FlagSet, error)
+	useShortOptionHandling() bool
+}
+
+// To enable short-option handling (e.g., "-it" vs "-i -t") we have to
+// iteratively catch parsing errors. This way we achieve LR parsing without
+// transforming any arguments. Otherwise, there is no way we can discriminate
+// combined short options from common arguments that should be left untouched.
+// Pass `shellComplete` to continue parsing options on failure during shell
+// completion when, the user-supplied options may be incomplete.
+func parseIter(set *flag.FlagSet, ip iterativeParser, args []string, shellComplete bool) error {
+	for {
+		err := set.Parse(args)
+		if !ip.useShortOptionHandling() || err == nil {
+			if shellComplete {
+				return nil
+			}
+			return err
+		}
+
+		errStr := err.Error()
+		trimmed := strings.TrimPrefix(errStr, "flag provided but not defined: -")
+		if errStr == trimmed {
+			return err
+		}
+
+		// regenerate the initial args with the split short opts
+		argsWereSplit := false
+		for i, arg := range args {
+			// skip args that are not part of the error message
+			if name := strings.TrimLeft(arg, "-"); name != trimmed {
+				continue
+			}
+
+			// if we can't split, the error was accurate
+			shortOpts := splitShortOptions(set, arg)
+			if len(shortOpts) == 1 {
+				return err
+			}
+
+			// swap current argument with the split version
+			args = append(args[:i], append(shortOpts, args[i+1:]...)...)
+			argsWereSplit = true
+			break
+		}
+
+		// This should be an impossible to reach code path, but in case the arg
+		// splitting failed to happen, this will prevent infinite loops
+		if !argsWereSplit {
+			return err
+		}
+
+		// Since custom parsing failed, replace the flag set before retrying
+		newSet, err := ip.newFlagSet()
+		if err != nil {
+			return err
+		}
+		*set = *newSet
+	}
+}
+
+func splitShortOptions(set *flag.FlagSet, arg string) []string {
+	shortFlagsExist := func(s string) bool {
+		for _, c := range s[1:] {
+			if f := set.Lookup(string(c)); f == nil {
+				return false
+			}
+		}
+		return true
+	}
+
+	if !isSplittable(arg) || !shortFlagsExist(arg) {
+		return []string{arg}
+	}
+
+	separated := make([]string, 0, len(arg)-1)
+	for _, flagChar := range arg[1:] {
+		separated = append(separated, "-"+string(flagChar))
+	}
+
+	return separated
+}
+
+func isSplittable(flagArg string) bool {
+	return strings.HasPrefix(flagArg, "-") && !strings.HasPrefix(flagArg, "--") && len(flagArg) > 2
+}

--- a/vendor/github.com/urfave/cli/sort.go
+++ b/vendor/github.com/urfave/cli/sort.go
@@ -1,0 +1,29 @@
+package cli
+
+import "unicode"
+
+// lexicographicLess compares strings alphabetically considering case.
+func lexicographicLess(i, j string) bool {
+	iRunes := []rune(i)
+	jRunes := []rune(j)
+
+	lenShared := len(iRunes)
+	if lenShared > len(jRunes) {
+		lenShared = len(jRunes)
+	}
+
+	for index := 0; index < lenShared; index++ {
+		ir := iRunes[index]
+		jr := jRunes[index]
+
+		if lir, ljr := unicode.ToLower(ir), unicode.ToLower(jr); lir != ljr {
+			return lir < ljr
+		}
+
+		if ir != jr {
+			return ir < jr
+		}
+	}
+
+	return i < j
+}

--- a/vendor/github.com/urfave/cli/template.go
+++ b/vendor/github.com/urfave/cli/template.go
@@ -1,0 +1,121 @@
+package cli
+
+// AppHelpTemplate is the text template for the Default help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var AppHelpTemplate = `NAME:
+   {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+
+VERSION:
+   {{.Version}}{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}{{if len .Authors}}
+
+AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
+   {{range $index, $author := .Authors}}{{if $index}}
+   {{end}}{{$author}}{{end}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
+GLOBAL OPTIONS:
+   {{range $index, $option := .VisibleFlags}}{{if $index}}
+   {{end}}{{$option}}{{end}}{{end}}{{if .Copyright}}
+
+COPYRIGHT:
+   {{.Copyright}}{{end}}
+`
+
+// CommandHelpTemplate is the text template for the command help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var CommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
+
+CATEGORY:
+   {{.Category}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}{{if .VisibleFlags}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+
+// SubcommandHelpTemplate is the text template for the subcommand help topic.
+// cli.go uses text/template to render templates. You can
+// render custom help text by setting this variable.
+var SubcommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{if .Description}}{{.Description}}{{else}}{{.Usage}}{{end}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
+
+COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+
+   {{.Name}}:{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+   {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+
+var MarkdownDocTemplate = `% {{ .App.Name }}(8) {{ .App.Description }}
+
+% {{ .App.Author }}
+
+# NAME
+
+{{ .App.Name }}{{ if .App.Usage }} - {{ .App.Usage }}{{ end }}
+
+# SYNOPSIS
+
+{{ .App.Name }}
+{{ if .SynopsisArgs }}
+` + "```" + `
+{{ range $v := .SynopsisArgs }}{{ $v }}{{ end }}` + "```" + `
+{{ end }}{{ if .App.UsageText }}
+# DESCRIPTION
+
+{{ .App.UsageText }}
+{{ end }}
+**Usage**:
+
+` + "```" + `
+{{ .App.Name }} [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
+` + "```" + `
+{{ if .GlobalArgs }}
+# GLOBAL OPTIONS
+{{ range $v := .GlobalArgs }}
+{{ $v }}{{ end }}
+{{ end }}{{ if .Commands }}
+# COMMANDS
+{{ range $v := .Commands }}
+{{ $v }}{{ end }}{{ end }}`
+
+var FishCompletionTemplate = `# {{ .App.Name }} fish shell completion
+
+function __fish_{{ .App.Name }}_no_subcommand --description 'Test if there has been any subcommand yet'
+    for i in (commandline -opc)
+        if contains -- $i{{ range $v := .AllCommands }} {{ $v }}{{ end }}
+            return 1
+        end
+    end
+    return 0
+end
+
+{{ range $v := .Completions }}{{ $v }}
+{{ end }}`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,0 +1,12 @@
+# github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
+## explicit; go 1.12
+github.com/cpuguy83/go-md2man/v2/md2man
+# github.com/russross/blackfriday/v2 v2.0.1
+## explicit
+github.com/russross/blackfriday/v2
+# github.com/shurcooL/sanitized_anchor_name v1.0.0
+## explicit
+github.com/shurcooL/sanitized_anchor_name
+# github.com/urfave/cli v1.22.10
+## explicit; go 1.11
+github.com/urfave/cli


### PR DESCRIPTION
Check the correctness of the given arguments. Integer arguments can not have negative values and strings can not be empty.

Most of the flags in the start command are not required. If the user does not specify them, we can use some default values. These options are: core, mem, net, blk.

Simplify stop and console commands. These commands can simply get one argument, instead of expecting one more flag.

Signed-off-by: Charalampos Mainas <charalampos.mainas@gmail.com>